### PR TITLE
ci: bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
@@ -42,18 +42,18 @@ jobs:
       CRYPTIFY_URL: https://fileshare.staging.postguard.eu
       POSTGUARD_WEBSITE_URL: https://staging.postguard.eu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push :edge
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -80,18 +80,18 @@ jobs:
       CRYPTIFY_URL: https://fileshare.postguard.eu
       POSTGUARD_WEBSITE_URL: https://postguard.eu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push release image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
Brings every action used in `.github/workflows/release.yml` to its latest major release as of 2026-05-04.

| Action | Was | Now |
|---|---|---|
| googleapis/release-please-action | v4 | v5 |
| actions/checkout | v4 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |

The output names we consume from release-please (`release_created`, `tag_name`, `version`) are unchanged in v5. No behavioural changes are expected from the Docker action bumps for this workflow's surface area.

## Test plan
- [ ] On merge, the next push to `master` triggers `release-please` and produces an `:edge` Docker image (or a release image if release-please opens/lands a Release-PR), all on the new action versions.