### PR TITLE
fix(nginx): keep inherited mime.types so HTML serves as text/html

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,10 +21,6 @@ server {
     add_header Referrer-Policy        "strict-origin-when-cross-origin" always;
     add_header Cache-Control          $addin_cache_control always;
 
-    types {
-        application/wasm wasm;
-    }
-
     # Permissive CORS so the Office runtime (and the manifest fetcher) can
     # load assets across origins.
     add_header Access-Control-Allow-Origin "*" always;


### PR DESCRIPTION
## Symptom
Clicking the PostGuard ribbon button in Outlook caused the browser to **download `taskpane.html`** instead of rendering the taskpane.

## Cause
`nginx/default.conf` had a server-scoped block:

\`\`\`nginx
types {
    application/wasm wasm;
}
\`\`\`

A `types {}` block at the server level **replaces** the inherited http-level `mime.types`, so every static file — `.html`, `.js`, `.css`, etc. — was served with no Content-Type. With `X-Content-Type-Options: nosniff` set, the browser refused to render and offered the file as a download.

## Fix
Drop the server-scoped block. nginx 1.27's bundled `/etc/nginx/mime.types` already includes `application/wasm wasm;`, so it was redundant.

## Verification
Local smoke test against the modified config:
- `GET /taskpane.html` → `Content-Type: text/html` ✓
- `GET /manifest.xml` → `Content-Type: text/xml` ✓

## Test plan
- [ ] On merge, master push rebuilds `:edge` against `addin.staging.postguard.eu`.
- [ ] Trigger an `addin-deployment` rollout-restart in `postguard-ops` dev (or `workflow_dispatch` on `deploy-dev.yml` with `restart_deployments: true`).
- [ ] Sideload the staging manifest in Outlook → ribbon click renders the taskpane (no download prompt).