### PR TITLE
fix(launchevent): derive Yivi dialog URL from runtime origin

### DIFF
--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -31,7 +31,12 @@ const HEADER_POSTGUARD = "x-postguard";
 const POSTGUARD_VERSION = "0.1.0";
 const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
 const COMPOSE_BUTTON_ID = "postGuardComposeButton";
-const YIVI_DIALOG_URL = "https://localhost:3000/yivi-dialog.html";
+// Derive the dialog URL from the runtime origin so the same code works
+// for dev sideload (localhost), staging (addin.staging.postguard.eu) and
+// production (addin.postguard.eu) without rewriting source. Office's
+// displayDialogAsync only allows same-origin dialogs, subdomains of the
+// source location, or domains explicitly listed in <AppDomains>.
+const YIVI_DIALOG_URL = new URL("yivi-dialog.html", window.location.href).toString();
 
 const NOT_ENCRYPTED_MESSAGE =
   "PostGuard is on but this message is not encrypted yet. " +


### PR DESCRIPTION
The hardcoded https://localhost:3000/yivi-dialog.html constant was never rewritten by webpack (only manifest.xml is), so OnMessageSend on addin.staging.postguard.eu and addin.postguard.eu tried to open a dialog on localhost. Office.displayDialogAsync rejected it because localhost is neither same-origin as the source location nor listed in <AppDomains>.