### PR TITLE
fix(launchevent): use build-time ADDIN_PUBLIC_URL for Yivi dialog URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,16 @@ There are no automated tests in this project.
 
 ## Build-time configuration
 
-Three URLs are baked into the bundle via webpack `DefinePlugin` (see `webpack.config.js`):
+Four URLs are baked into the bundle via webpack `DefinePlugin` (see `webpack.config.js`):
 
 - `PKG_URL` — PostGuard Key Generation server.
 - `CRYPTIFY_URL` — Cryptify file-share service.
 - `POSTGUARD_WEBSITE_URL` — used by the SDK envelope for the browser fallback link.
+- `ADDIN_PUBLIC_URL` — the add-in's own public origin (e.g. `https://addin.postguard.eu/`). Used by `launchevent.ts` to build the Yivi dialog URL; `window.location` is unreliable in the launchevent runtime on New Outlook for Mac. Webpack picks `urlDev` in dev mode and `urlProd` (overridable via this env var) otherwise.
 
 These are read from `.env` (copy `.env.example`) or fall back to staging defaults. They are accessed through `src/lib/pkg-client.ts` — do not read `process.env` elsewhere.
 
-The webpack config also rewrites `https://localhost:3000/` → `https://addin.postguard.eu/` inside `manifest.xml` when building in non-development mode, so the *same* manifest is used for dev sideloading and production hosting.
+The webpack config also rewrites `https://localhost:3000/` → `ADDIN_PUBLIC_URL` (default `https://addin.postguard.eu/`) inside `manifest.xml` when building in non-development mode, so the *same* manifest is used for dev sideloading and production hosting.
 
 ## Architecture
 

--- a/docs/outlook-quirks.md
+++ b/docs/outlook-quirks.md
@@ -109,6 +109,19 @@ Despite docs implying it's a general per-session state mechanism, `sessionData`
 methods are not available in launch event handlers. Don't reach for it for
 taskpane↔send-handler communication.
 
+### `window.location.href` in the launchevent runtime is *not* the add-in origin on every host
+
+On Outlook on Web and new Outlook on Windows, the launchevent runtime loads
+`launchevent.html` from your `<bt:Url id="WebViewRuntime.Url">`, so
+`window.location.href` is the add-in origin and you can derive other URLs from
+it. New Outlook for Mac instead uses the `<Override type="javascript"
+resid="JSRuntime.Url"/>` branch and runs `launchevent.js` directly — there
+`window.location` resolves to an Office-internal URL, not the add-in. Passing
+that to `displayDialogAsync` fails with the unhelpful `An internal error has
+occurred.` Use a build-time-injected `process.env.ADDIN_PUBLIC_URL` (see
+`webpack.config.js` DefinePlugin) for any absolute URL the launchevent
+handler hands back to Office.
+
 ---
 
 ## Office.js compose-mode quirks

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -24,6 +24,7 @@ import {
   isChunkMessage,
   ChunkMessage,
 } from "../lib/dialog-chunk";
+import { ADDIN_PUBLIC_URL } from "../lib/pkg-client";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
@@ -31,12 +32,13 @@ const HEADER_POSTGUARD = "x-postguard";
 const POSTGUARD_VERSION = "0.1.0";
 const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
 const COMPOSE_BUTTON_ID = "postGuardComposeButton";
-// Derive the dialog URL from the runtime origin so the same code works
-// for dev sideload (localhost), staging (addin.staging.postguard.eu) and
-// production (addin.postguard.eu) without rewriting source. Office's
-// displayDialogAsync only allows same-origin dialogs, subdomains of the
-// source location, or domains explicitly listed in <AppDomains>.
-const YIVI_DIALOG_URL = new URL("yivi-dialog.html", window.location.href).toString();
+// Build the dialog URL from the add-in's public origin, injected at
+// build time. window.location.href is unreliable here: New Outlook for
+// Mac runs launchevent.js via the JSRuntime.Url override, where
+// window.location resolves to an Office-internal URL rather than the
+// add-in origin, and displayDialogAsync rejects with "An internal error
+// has occurred."
+const YIVI_DIALOG_URL = `${ADDIN_PUBLIC_URL}yivi-dialog.html`;
 
 const NOT_ENCRYPTED_MESSAGE =
   "PostGuard is on but this message is not encrypted yet. " +

--- a/src/lib/pkg-client.ts
+++ b/src/lib/pkg-client.ts
@@ -4,6 +4,10 @@
 export const PKG_URL: string = process.env.PKG_URL as string;
 export const CRYPTIFY_URL: string = process.env.CRYPTIFY_URL as string;
 export const POSTGUARD_WEBSITE_URL: string = process.env.POSTGUARD_WEBSITE_URL as string;
+// Add-in's own public origin (e.g. https://addin.postguard.eu/). Used by the
+// OnMessageSend launchevent runtime to construct the Yivi dialog URL —
+// window.location is unreliable there on New Outlook for Mac.
+export const ADDIN_PUBLIC_URL: string = process.env.ADDIN_PUBLIC_URL as string;
 
 export const CLIENT_NAME = "Outlook";
 export const CLIENT_ID = "pg4ol";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,12 @@ module.exports = async (env, options) => {
         "process.env.PKG_URL": JSON.stringify(resolvedEnv.PKG_URL),
         "process.env.CRYPTIFY_URL": JSON.stringify(resolvedEnv.CRYPTIFY_URL),
         "process.env.POSTGUARD_WEBSITE_URL": JSON.stringify(resolvedEnv.POSTGUARD_WEBSITE_URL),
+        // The add-in's own public origin. Needed by launchevent.ts to
+        // build the Yivi dialog URL — window.location.href is unreliable
+        // there because New Outlook for Mac runs the launchevent JS
+        // override (JSRuntime.Url) where window.location is an Office-
+        // internal URL, not the add-in origin.
+        "process.env.ADDIN_PUBLIC_URL": JSON.stringify(dev ? urlDev : urlProd),
       }),
       new HtmlWebpackPlugin({
         filename: "taskpane.html",


### PR DESCRIPTION
## Summary
Fixes `displayDialogAsync` errors when sending an encrypted message via the OnMessageSend Smart Alert flow.

- `YIVI_DIALOG_URL` was hardcoded to `https://localhost:3000/yivi-dialog.html`. Webpack only rewrites `localhost:3000` inside `manifest.xml`, so the localhost URL shipped in the bundle and Office rejected the dialog on every non-dev host: `displayDialogAsync failed: Het domein van de URL is niet opgenomen in het AppDomains element in het manifest...`
- First attempt derived the URL from `window.location.href` at runtime. That works on Outlook on Web and new Outlook on Windows (both load `launchevent.html` from the add-in origin), but **New Outlook for Mac** runs the `<Override type="javascript" resid="JSRuntime.Url"/>` branch and executes `launchevent.js` directly — there `window.location` resolves to an Office-internal URL, so the dialog URL came out garbage and Office returned the unhelpful `An internal error has occurred.`
- Fix: bake the add-in's public origin in at build time via webpack `DefinePlugin` (`ADDIN_PUBLIC_URL`), alongside the existing `PKG_URL` / `CRYPTIFY_URL` / `POSTGUARD_WEBSITE_URL` pattern. Expose it through `src/lib/pkg-client.ts` to honor the "do not read `process.env` elsewhere" rule from `CLAUDE.md`.
- Documented the launchevent-runtime difference in `docs/outlook-quirks.md` so the next person doesn't re-discover it.

## Test plan
- [ ] **New Outlook for Mac (staging):** send a PostGuard-encrypted message via the OnMessageSend flow → Yivi dialog opens, encryption completes, send proceeds.
- [ ] **Outlook on Web / new Outlook on Windows (staging):** same flow → no regression.
- [ ] **Dev sideload (`npm start`):** Yivi dialog still loads from `https://localhost:3000/yivi-dialog.html`.
- [ ] `grep ADDIN_PUBLIC_URL dist/launchevent.js` shows the expected origin per build mode.