### PR TITLE
debug(launchevent): surface displayDialogAsync diagnostics in Smart Alert

### DIFF
--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -257,6 +257,21 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
+    // Diagnostic context surfaced in the Smart Alert when displayDialogAsync
+     // fails. New Outlook for Mac is currently the main offender — it
+     // returns "An internal error has occurred." with no further detail,
+     // so we attach platform/host/requirement-set info to the rejection.
+    const platform = String(Office.context.platform ?? "?");
+    const host = String(Office.context.host ?? "?");
+    const supports113 = (() => {
+      try {
+        return Office.context.requirements.isSetSupported("Mailbox", "1.13");
+      } catch {
+        return false;
+      }
+    })();
+    log(`pre-dialog diagnostics platform=${platform} host=${host} mbx1.13=${supports113} url=${YIVI_DIALOG_URL}`);
+
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
       // promptBeforeOpen: false suppresses the "PostGuard is opening
@@ -267,7 +282,18 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
+          const err = asyncResult.error;
+          const detail = [
+            `displayDialogAsync failed: ${err?.message ?? "(no message)"}`,
+            `code=${err?.code ?? "?"}`,
+            `name=${err?.name ?? "?"}`,
+            `platform=${platform}`,
+            `host=${host}`,
+            `mbx1.13=${supports113}`,
+            `url=${YIVI_DIALOG_URL}`,
+          ].join(" | ");
+          log(`displayDialogAsync rejected: ${detail}`);
+          reject(new Error(detail));
           return;
         }
         const dialog = asyncResult.value;


### PR DESCRIPTION
## Summary
Follow-up to #21. After deploying the URL fix, New Outlook for Mac still rejected `displayDialogAsync` with the unhelpful "An internal error has occurred." and the Outlook runtime log only showed generic `AddinError:9` entries — no way to tell whether it's a missing requirement set, an unsupported dialog option, or a real platform bug.

This PR captures `Office.context.platform`, `host`, `requirements.isSetSupported("Mailbox", "1.13")`, and the `asyncResult.error` `code`/`name`/`message` at the rejection point and includes them in the `Error` that bubbles up to `block()`. The Smart Alert the user sees now contains everything we'd otherwise have to fish out of Web Inspector or the runtime log.

## Why
The two values that disambiguate the failure:

- **`mbx1.13=false`** → Microsoft hasn't shipped dialog-from-event-handler support to that Mac build yet. We'll need a Mac-specific fallback that requires the manual taskpane "Encrypt & Send" path instead of the OnMessageSend dialog flow.
- **`mbx1.13=true` + `code=12xxx`** → real platform bug or one of the dialog options (`displayInIframe: false`, `promptBeforeOpen: false`) isn't honored on Mac.

Either way, the new diagnostic string makes the next round of testing actionable.

## Test plan
- [ ] Build with `ADDIN_PUBLIC_URL=https://addin.staging.postguard.eu/ npm run build`, deploy to staging, re-sideload manifest in New Outlook for Mac.
- [ ] Trigger OnMessageSend → confirm the Smart Alert message contains `platform=`, `host=`, `mbx1.13=`, and `code=` fields.
- [ ] No regression on Outlook on Web / new Outlook on Windows (success path is unchanged; diagnostic context is only attached to the rejection branch).