### PR TITLE
fix: allowlist add-in domain in <AppDomains> for launchevent dialogs

### DIFF
--- a/docs/outlook-quirks.md
+++ b/docs/outlook-quirks.md
@@ -109,6 +109,25 @@ Despite docs implying it's a general per-session state mechanism, `sessionData`
 methods are not available in launch event handlers. Don't reach for it for
 taskpane↔send-handler communication.
 
+### `displayDialogAsync` from the launchevent runtime needs the add-in domain in `<AppDomains>`
+
+A dialog opened from the regular taskpane is allowed without an `<AppDomains>`
+entry as long as it's same-origin with `<SourceLocation>`. From the *launchevent*
+runtime that rule does not apply: the runtime is hosted inside an
+`outlook.office.com` iframe, so from its point of view the dialog URL is
+cross-origin and Office checks the manifest's `<AppDomains>`. Symptoms:
+
+- **Outlook on the web** rejects with `code=12011` (`BlockedNavigation`) and a
+  message about "different security zones".
+- **New Outlook for Mac** rejects with the generic E_FAIL (HRESULT
+  `-2147467259`, message "An internal error has occurred."). Same root cause,
+  uglier wrapper.
+
+Fix: list the add-in's own host in `<AppDomains>` (`https://addin.postguard.eu`,
+`https://addin.staging.postguard.eu`, and `https://localhost:3000` for the dev
+sideload). It's only the launchevent dialog path that needs this; the taskpane
+keeps working without the explicit entry.
+
 ### `window.location.href` in the launchevent runtime is *not* the add-in origin on every host
 
 On Outlook on Web and new Outlook on Windows, the launchevent runtime loads

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,6 +13,14 @@
     <AppDomain>https://postguard.eu</AppDomain>
     <AppDomain>https://staging.postguard.eu</AppDomain>
     <AppDomain>https://yivi.app</AppDomain>
+    <!-- Required for Office.context.ui.displayDialogAsync from the
+         OnMessageSend launchevent runtime. That runtime is hosted inside
+         an outlook.office.com iframe, so the dialog URL counts as
+         cross-origin relative to it and must be allowlisted explicitly,
+         even though it is the same domain as <SourceLocation>. -->
+    <AppDomain>https://addin.postguard.eu</AppDomain>
+    <AppDomain>https://addin.staging.postguard.eu</AppDomain>
+    <AppDomain>https://localhost:3000</AppDomain>
   </AppDomains>
   <Hosts>
     <Host Name="Mailbox"/>

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,19 +236,11 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
-// New Outlook for Mac (≥16.84) advertises Mailbox 1.13 and is supposed
-// to support displayDialogAsync from a launchevent runtime, but in
-// practice rejects small dialogs (we observed E_FAIL / -2147467259 with
-// width≈16% on a 1920-wide screen). The Web/Windows runtimes silently
-// clamp; Mac doesn't. Floor at 30% to stay above whatever minimum Mac's
-// dialog manager actually enforces.
-const MIN_DIALOG_PCT = 30;
-
 function pctOfScreen(targetPx: number, screenPx: number): number {
   // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
   // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
+  return Math.min(99, Math.max(1, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for
@@ -265,47 +257,17 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // Diagnostic context surfaced in the Smart Alert when displayDialogAsync
-     // fails. New Outlook for Mac is currently the main offender — it
-     // returns "An internal error has occurred." with no further detail,
-     // so we attach platform/host/requirement-set info to the rejection.
-    const platform = String(Office.context.platform ?? "?");
-    const host = String(Office.context.host ?? "?");
-    const supports113 = (() => {
-      try {
-        return Office.context.requirements.isSetSupported("Mailbox", "1.13");
-      } catch {
-        return false;
-      }
-    })();
-    log(`pre-dialog diagnostics platform=${platform} host=${host} mbx1.13=${supports113} url=${YIVI_DIALOG_URL}`);
-
-    // displayInIframe and promptBeforeOpen used to be set explicitly here
-    // (false / false). On New Outlook for Mac that combination caused
-    // displayDialogAsync to reject with E_FAIL (-2147467259) before any
-    // navigation attempt. Falling back to defaults — popup window with
-    // the "open another window" prompt — is what Mac WebKit actually
-    // permits from a launchevent runtime. The prompt is harmless on
-    // Web/Windows so we accept it everywhere rather than branching.
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct },
+      // promptBeforeOpen: false suppresses the "PostGuard is opening
+      // another window" confirmation. Honored because the dialog URL is
+      // on the same origin as the add-in's source location. Requires
+      // Mailbox 1.9 (we require 1.12 in VersionOverridesV1_1).
+      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: false },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          const err = asyncResult.error;
-          const detail = [
-            `displayDialogAsync failed: ${err?.message ?? "(no message)"}`,
-            `code=${err?.code ?? "?"}`,
-            `name=${err?.name ?? "?"}`,
-            `platform=${platform}`,
-            `host=${host}`,
-            `mbx1.13=${supports113}`,
-            `size=${widthPct}%×${heightPct}%`,
-            `url=${YIVI_DIALOG_URL}`,
-          ].join(" | ");
-          log(`displayDialogAsync rejected: ${detail}`);
-          reject(new Error(detail));
+          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
           return;
         }
         const dialog = asyncResult.value;

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,11 +236,19 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
+// New Outlook for Mac (≥16.84) advertises Mailbox 1.13 and is supposed
+// to support displayDialogAsync from a launchevent runtime, but in
+// practice rejects small dialogs (we observed E_FAIL / -2147467259 with
+// width≈16% on a 1920-wide screen). The Web/Windows runtimes silently
+// clamp; Mac doesn't. Floor at 30% to stay above whatever minimum Mac's
+// dialog manager actually enforces.
+const MIN_DIALOG_PCT = 30;
+
 function pctOfScreen(targetPx: number, screenPx: number): number {
   // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
   // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(1, pct));
+  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for
@@ -293,6 +301,7 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
             `platform=${platform}`,
             `host=${host}`,
             `mbx1.13=${supports113}`,
+            `size=${widthPct}%×${heightPct}%`,
             `url=${YIVI_DIALOG_URL}`,
           ].join(" | ");
           log(`displayDialogAsync rejected: ${detail}`);

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -272,13 +272,16 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     })();
     log(`pre-dialog diagnostics platform=${platform} host=${host} mbx1.13=${supports113} url=${YIVI_DIALOG_URL}`);
 
+    // displayInIframe and promptBeforeOpen used to be set explicitly here
+    // (false / false). On New Outlook for Mac that combination caused
+    // displayDialogAsync to reject with E_FAIL (-2147467259) before any
+    // navigation attempt. Falling back to defaults — popup window with
+    // the "open another window" prompt — is what Mac WebKit actually
+    // permits from a launchevent runtime. The prompt is harmless on
+    // Web/Windows so we accept it everywhere rather than branching.
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      // promptBeforeOpen: false suppresses the "PostGuard is opening
-      // another window" confirmation. Honored because the dialog URL is
-      // on the same origin as the add-in's source location. Requires
-      // Mailbox 1.9 (we require 1.12 in VersionOverridesV1_1).
-      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: false },
+      { height: heightPct, width: widthPct },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {


### PR DESCRIPTION
## Summary
This is the actual fix for the OnMessageSend `displayDialogAsync` failures we've been chasing. Tested working on staging via Outlook on the web *and* New Outlook for Mac.

The launchevent runtime is hosted inside an `outlook.office.com` iframe, so from its point of view a dialog on the add-in's own URL is cross-origin — even though it's the same domain as `<SourceLocation>`. Office checks `<AppDomains>` for that case. Symptoms before the fix:

- **Outlook on the web**: `code=12011 BlockedNavigation` — "the dialog domain and add-in host domain are not in the same security zone."
- **New Outlook for Mac**: same root cause, surfaced as the generic E_FAIL (`code=-2147467259`, "An internal error has occurred.").

The same-origin-without-allowlist rule applies to dialogs from a *taskpane*, which is why the symptom was launchevent-only and threw us off for several rounds.

## Changes
- `manifest.xml`: add `addin.postguard.eu`, `addin.staging.postguard.eu`, and `localhost:3000` to `<AppDomains>` with a comment explaining why.
- `docs/outlook-quirks.md`: new section documenting the launchevent → `<AppDomains>` requirement and the Web (12011) vs Mac (E_FAIL) symptom split.
- `src/launchevent/launchevent.ts`: revert the diagnostics-in-Smart-Alert instrumentation that was merged via #22 — it served its purpose during the investigation, no longer needed.

## Test plan
- [x] Outlook on the web: send with PostGuard encrypt-on-send → Yivi dialog opens.
- [x] New Outlook for Mac: same flow → Yivi dialog opens.
- [ ] Sideload via `npm start` (localhost) → no regression.
- [ ] Production build smoke test once staging passes.