### PR TITLE
fix(launchevent): always show Office popup prompt so dialogs open

### DIFF
--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,18 +263,39 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // promptBeforeOpen MUST stay at the default (true). The Office-level
-    // "PostGuard is opening another window" confirmation is the user
-    // gesture that releases the popup the dialog needs. Without it Mac
-    // WKWebView and any Web browser without a previously-granted popup
-    // permission silently block the popup with no surfaced UI.
+    // promptBeforeOpen branches on rendering engine, not Office's
+    // platform enum. Apple WebKit — Safari and the WKWebView that New
+    // Outlook for Mac runs on — has no per-site popup permission UI
+    // reachable from a launchevent runtime, so the Office-level
+    // "PostGuard is opening another window" prompt is the only user
+    // gesture that releases the popup; we keep it on (true) there.
+    // Blink (Chrome, Edge) and Gecko (Firefox) handle background
+    // popups without intervention, so we skip the extra prompt for a
+    // one-click send. Office.context.platform reports "OfficeOnline"
+    // for every browser on the web, so we match on UA instead.
+    const ua = navigator.userAgent || "";
+    const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
+    const platformDebug =
+      `ua=${ua} | platform=${Office.context.platform} ` +
+      `isAppleWebKit=${isAppleWebKit} promptBeforeOpen=${isAppleWebKit}`;
+    log(platformDebug);
+
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false },
+      {
+        height: heightPct,
+        width: widthPct,
+        displayInIframe: false,
+        promptBeforeOpen: isAppleWebKit,
+      },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
+          reject(
+            new Error(
+              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
+            )
+          );
           return;
         }
         const dialog = asyncResult.value;

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,11 +236,17 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
+// Floor the dialog size at 30% of the screen. The popup blocker — fixed
+// via promptBeforeOpen — was the real cause of the launchevent dialog
+// failures, but on a 3440×1440 ultrawide our 300px target still resolves
+// to 9% width, which renders the Yivi QR uncomfortably small even when
+// the host accepts it. 30% gives the dialog enough room for the QR plus
+// title and Cancel button across screen sizes.
+const MIN_DIALOG_PCT = 30;
+
 function pctOfScreen(targetPx: number, screenPx: number): number {
-  // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
-  // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(1, pct));
+  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,35 +263,18 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // promptBeforeOpen branches on platform. New Outlook for Mac
-    // (WKWebView) has no per-site popup-permission UI, so the Office-
-    // level "PostGuard is opening another window" prompt is the only
-    // user gesture that releases the popup — keep it on (true). On
-    // Web/Windows the host browser exposes its own popup permission;
-    // once granted, the popup opens with no extra prompt needed, so
-    // suppressing the Office prompt (false) gives a one-click send.
-    // First-time Web users may need to allow popups for the host once
-    // via the browser's native indicator.
-    const rawPlatform = Office.context.platform;
-    const platformTypeMac = Office.PlatformType?.Mac;
-    const isMac = rawPlatform === platformTypeMac;
-    const platformDebug =
-      `rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
-      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
-      `isMac=${isMac} promptBeforeOpen=${isMac}`;
-    log(platformDebug);
-
+    // promptBeforeOpen MUST stay at the default (true). The Office-level
+    // "PostGuard is opening another window" confirmation is the user
+    // gesture that releases the popup the dialog needs. Without it Mac
+    // WKWebView and any Web browser without a previously-granted popup
+    // permission silently block the popup with no surfaced UI.
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
+      { height: heightPct, width: widthPct, displayInIframe: false },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(
-            new Error(
-              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
-            )
-          );
+          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
           return;
         }
         const dialog = asyncResult.value;
@@ -558,16 +541,6 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
 log("script loaded");
 Office.onReady((info) => {
   log(`Office.onReady fired; host=${info?.host} platform=${info?.platform}`);
-  // Eager platform diagnostic so DevTools shows it without waiting for
-  // a Send + handler dispatch + dialog open. Same logic that decides
-  // promptBeforeOpen inside runEncryptDialog.
-  const rawPlatform = Office.context?.platform;
-  const platformTypeMac = Office.PlatformType?.Mac;
-  log(
-    `platform check: rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
-      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
-      `isMac=${rawPlatform === platformTypeMac}`
-  );
   Office.actions.associate("onMessageSendHandler", onMessageSendHandler);
   log("handler associated");
 });

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -272,8 +272,14 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     // suppressing the Office prompt (false) gives a one-click send.
     // First-time Web users may need to allow popups for the host once
     // via the browser's native indicator.
-    const isMac = Office.context.platform === Office.PlatformType.Mac;
-    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
+    const rawPlatform = Office.context.platform;
+    const platformTypeMac = Office.PlatformType?.Mac;
+    const isMac = rawPlatform === platformTypeMac;
+    const platformDebug =
+      `rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
+      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
+      `isMac=${isMac} promptBeforeOpen=${isMac}`;
+    log(platformDebug);
 
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
@@ -281,7 +287,11 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
+          reject(
+            new Error(
+              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
+            )
+          );
           return;
         }
         const dialog = asyncResult.value;

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -243,140 +243,158 @@ function pctOfScreen(targetPx: number, screenPx: number): number {
   return Math.min(99, Math.max(1, pct));
 }
 
+// Promise wrapper around displayDialogAsync. Resolves with the dialog
+// handle on success, rejects with the Office error otherwise.
+function openDialogAsync(
+  url: string,
+  options: Office.DialogOptions
+): Promise<Office.Dialog> {
+  return new Promise((resolve, reject) => {
+    Office.context.ui.displayDialogAsync(url, options, (asyncResult) => {
+      if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(asyncResult.value);
+      } else {
+        reject(asyncResult.error ?? new Error("displayDialogAsync failed"));
+      }
+    });
+  });
+}
+
 // Opens the Yivi dialog with an encrypt-request payload and waits for
 // the dialog to post the encrypted result back. Resolves with the
 // envelope; rejects on error or user cancel.
-function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
+async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
+  // window.screen.* is in CSS pixels (matching what Office's percentage
+  // interprets). Falls back to a safe 1920×1080 if the launchevent
+  // runtime ever surfaces an empty screen object.
+  const screenW = window.screen?.width || 1920;
+  const screenH = window.screen?.height || 1080;
+  const widthPct = pctOfScreen(YIVI_DIALOG_TARGET_WIDTH_PX, screenW);
+  const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
+  log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
+
+  const baseOptions: Office.DialogOptions = {
+    height: heightPct,
+    width: widthPct,
+    displayInIframe: false,
+  };
+
+  // Try to open the dialog without Office's "open another window"
+  // prompt first. Browsers that allow popups from the Outlook host
+  // (Chrome/Edge/Firefox by default, and Safari once the user has
+  // granted permission once) get a one-click send. If that attempt
+  // fails — typically because Apple WebKit blocked the popup with no
+  // surfaced UI — retry with promptBeforeOpen: true so the Office
+  // prompt fires and the user's click on Allow becomes the gesture
+  // that releases the popup. The dialog itself shows a Safari-only
+  // hint pointing at Settings → Websites → Pop-ups so the user can
+  // skip the prompt on subsequent sends.
+  let dialog: Office.Dialog;
+  try {
+    log("displayDialogAsync attempt 1: promptBeforeOpen=false");
+    dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+      ...baseOptions,
+      promptBeforeOpen: false,
+    });
+    log("dialog opened (no prompt)");
+  } catch (e1) {
+    const msg1 = (e1 as { message?: string })?.message ?? String(e1);
+    log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
+    try {
+      dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+        ...baseOptions,
+        promptBeforeOpen: true,
+      });
+      log("dialog opened (after prompt)");
+    } catch (e2) {
+      const msg2 = (e2 as { message?: string })?.message ?? String(e2);
+      throw new Error(`displayDialogAsync failed: ${msg2}`);
+    }
+  }
+
   return new Promise((resolve, reject) => {
-    // window.screen.* is in CSS pixels (matching what Office's
-    // percentage interprets). Falls back to a safe 1920×1080 if Office's
-    // launchevent runtime ever surfaces an empty screen object.
-    const screenW = window.screen?.width || 1920;
-    const screenH = window.screen?.height || 1080;
-    const widthPct = pctOfScreen(YIVI_DIALOG_TARGET_WIDTH_PX, screenW);
-    const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
-    log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
+    const inbound = new ChunkAssembler();
+    let settled = false;
+    // Auto-close on success/error so the user isn't left with a
+    // stale "Encrypted and sent. You can close this window." dialog
+    // after the Send has been released — flip DEBUG_KEEP_DIALOG_OPEN
+    // to opt out when DevTools/log inspection is needed. Cancel
+    // closes itself from the dialog (window.close on the button).
+    const closeDialog = (): void => {
+      if (DEBUG_KEEP_DIALOG_OPEN) return;
+      try {
+        dialog.close();
+      } catch (e) {
+        log(`dialog.close failed: ${String(e)}`);
+      }
+    };
+    const settle = (cb: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cb();
+    };
 
-    // promptBeforeOpen branches on rendering engine, not Office's
-    // platform enum. Apple WebKit — Safari and the WKWebView that New
-    // Outlook for Mac runs on — has no per-site popup permission UI
-    // reachable from a launchevent runtime, so the Office-level
-    // "PostGuard is opening another window" prompt is the only user
-    // gesture that releases the popup; we keep it on (true) there.
-    // Blink (Chrome, Edge) and Gecko (Firefox) handle background
-    // popups without intervention, so we skip the extra prompt for a
-    // one-click send. Office.context.platform reports "OfficeOnline"
-    // for every browser on the web, so we match on UA instead.
-    const ua = navigator.userAgent || "";
-    const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
-    const platformDebug =
-      `ua=${ua} | platform=${Office.context.platform} ` +
-      `isAppleWebKit=${isAppleWebKit} promptBeforeOpen=${isAppleWebKit}`;
-    log(platformDebug);
+    const dispatch = (body: DialogMessage): void => {
+      log(`dialog → handler: ${body.type}`);
+      switch (body.type) {
+        case "ready": {
+          const chunks = chunkPayload(payload);
+          log(`sending ${chunks.length} chunk(s) to dialog`);
+          for (const c of chunks) {
+            dialog.messageChild(JSON.stringify(c));
+          }
+          break;
+        }
+        case "encrypt-result":
+          settle(() => {
+            closeDialog();
+            resolve(body as unknown as EncryptResult);
+          });
+          break;
+        case "encrypt-error":
+          settle(() => {
+            closeDialog();
+            reject(new Error(String(body.message ?? "Encryption failed")));
+          });
+          break;
+        case "cancelled":
+          settle(() => reject(new Error("Cancelled in dialog")));
+          break;
+        default:
+          log(`unhandled dialog message: ${body.type}`);
+      }
+    };
 
-    Office.context.ui.displayDialogAsync(
-      YIVI_DIALOG_URL,
-      {
-        height: heightPct,
-        width: widthPct,
-        displayInIframe: false,
-        promptBeforeOpen: isAppleWebKit,
-      },
-      (asyncResult) => {
-        log(`displayDialogAsync status=${asyncResult.status}`);
-        if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(
-            new Error(
-              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
-            )
-          );
+    dialog.addEventHandler(
+      Office.EventType.DialogMessageReceived,
+      (arg: { message: string } | { error: number }) => {
+        if ("error" in arg) {
+          log(`dialog message error: ${arg.error}`);
+          settle(() => reject(new Error(`Dialog error ${arg.error}`)));
           return;
         }
-        const dialog = asyncResult.value;
-        const inbound = new ChunkAssembler();
-        let settled = false;
-        // Auto-close on success/error so the user isn't left with a
-        // stale "Encrypted and sent. You can close this window." dialog
-        // after the Send has been released — flip DEBUG_KEEP_DIALOG_OPEN
-        // to opt out when DevTools/log inspection is needed. Cancel
-        // closes itself from the dialog (window.close on the button).
-        const closeDialog = (): void => {
-          if (DEBUG_KEEP_DIALOG_OPEN) return;
-          try {
-            dialog.close();
-          } catch (e) {
-            log(`dialog.close failed: ${String(e)}`);
-          }
-        };
-        const settle = (cb: () => void): void => {
-          if (settled) return;
-          settled = true;
-          cb();
-        };
-
-        const dispatch = (body: DialogMessage): void => {
-          log(`dialog → handler: ${body.type}`);
-          switch (body.type) {
-            case "ready": {
-              const chunks = chunkPayload(payload);
-              log(`sending ${chunks.length} chunk(s) to dialog`);
-              for (const c of chunks) {
-                dialog.messageChild(JSON.stringify(c));
-              }
-              break;
-            }
-            case "encrypt-result":
-              settle(() => {
-                closeDialog();
-                resolve(body as unknown as EncryptResult);
-              });
-              break;
-            case "encrypt-error":
-              settle(() => {
-                closeDialog();
-                reject(new Error(String(body.message ?? "Encryption failed")));
-              });
-              break;
-            case "cancelled":
-              settle(() => reject(new Error("Cancelled in dialog")));
-              break;
-            default:
-              log(`unhandled dialog message: ${body.type}`);
-          }
-        };
-
-        dialog.addEventHandler(
-          Office.EventType.DialogMessageReceived,
-          (arg: { message: string } | { error: number }) => {
-            if ("error" in arg) {
-              log(`dialog message error: ${arg.error}`);
-              settle(() => reject(new Error(`Dialog error ${arg.error}`)));
-              return;
-            }
-            let body: DialogMessage;
-            try {
-              body = JSON.parse(arg.message) as DialogMessage;
-            } catch {
-              log(`could not parse dialog message: ${arg.message}`);
-              return;
-            }
-            if (isChunkMessage(body)) {
-              const reassembled = inbound.ingest(body as ChunkMessage);
-              if (reassembled) dispatch(reassembled as DialogMessage);
-              return;
-            }
-            dispatch(body);
-          }
-        );
-
-        dialog.addEventHandler(Office.EventType.DialogEventReceived, (arg) => {
-          log(`dialog event: ${JSON.stringify(arg)}`);
-          if ("error" in arg && arg.error === 12006) {
-            settle(() => reject(new Error("Dialog closed by user")));
-          }
-        });
+        let body: DialogMessage;
+        try {
+          body = JSON.parse(arg.message) as DialogMessage;
+        } catch {
+          log(`could not parse dialog message: ${arg.message}`);
+          return;
+        }
+        if (isChunkMessage(body)) {
+          const reassembled = inbound.ingest(body as ChunkMessage);
+          if (reassembled) dispatch(reassembled as DialogMessage);
+          return;
+        }
+        dispatch(body);
       }
     );
+
+    dialog.addEventHandler(Office.EventType.DialogEventReceived, (arg) => {
+      log(`dialog event: ${JSON.stringify(arg)}`);
+      if ("error" in arg && arg.error === 12006) {
+        settle(() => reject(new Error("Dialog closed by user")));
+      }
+    });
   });
 }
 

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,21 +263,17 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // promptBeforeOpen branches on platform. On Mac the WKWebView
-    // popup blocker has no per-site override the user can reach, so the
-    // Office-level "PostGuard is opening another window" prompt is the
-    // only user gesture that releases the popup — keep it on (true).
-    // On Web/Windows, browsers expose their own popup-permission UI, so
-    // a returning user with permission granted can skip the extra
-    // Office prompt for a one-click flow (false). Brand-new Web users
-    // still see the browser's native popup-blocker indicator on the
-    // first send and can accept there once.
-    const isMac = Office.context.platform === Office.PlatformType.Mac;
-    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
-
+    // promptBeforeOpen MUST stay at its default (true). The Office-level
+    // "PostGuard is opening another window" confirmation is the user
+    // gesture that releases the popup the dialog needs — without it Mac
+    // WKWebView and any Web browser without a previously-granted popup
+    // permission silently block the popup with no recoverable error.
+    // Suppressing it (false) appears to work on returning Safari users
+    // whose host permission is cached, but breaks every fresh session
+    // and every Mac install.
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
+      { height: heightPct, width: widthPct, displayInIframe: false },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,17 +263,21 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // promptBeforeOpen MUST stay at the default (true). The Office-level
-    // "PostGuard is opening another window" confirmation is what gives
-    // displayDialogAsync a user gesture; without it, browsers and Mac's
-    // WKWebView silently block the popup the dialog needs. Web users had
-    // it working previously only because they had already clicked Allow
-    // once and Safari remembered. The launchevent context counts as a
-    // background event, not a user-initiated action, so we cannot suppress
-    // the prompt the way a taskpane button click could.
+    // promptBeforeOpen branches on platform. On Mac the WKWebView
+    // popup blocker has no per-site override the user can reach, so the
+    // Office-level "PostGuard is opening another window" prompt is the
+    // only user gesture that releases the popup — keep it on (true).
+    // On Web/Windows, browsers expose their own popup-permission UI, so
+    // a returning user with permission granted can skip the extra
+    // Office prompt for a one-click flow (false). Brand-new Web users
+    // still see the browser's native popup-blocker indicator on the
+    // first send and can accept there once.
+    const isMac = Office.context.platform === Office.PlatformType.Mac;
+    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
+
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false },
+      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -264,23 +264,19 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
     // New Outlook for Mac (WKWebView) blocks popup windows from a
-    // launchevent runtime with no per-site override available to the
-    // user, which makes the popup-mode dialog (displayInIframe: false)
-    // fail with the misleading "different security zones" error 12011 —
-    // surfaced as a generic E_FAIL on Mac. iframe mode bypasses the
-    // popup blocker. It is reportedly broken in Outlook on the web
-    // (office-js#2129) so we keep popup mode there. Detect Mac via
-    // Office.context.platform and branch the option.
+    // launchevent runtime, and iframe mode (displayInIframe: true) had
+    // no parent surface to render into. The remaining lever is the
+    // Office-level "open another window" prompt: with promptBeforeOpen:
+    // true Office shows its own confirmation that the user can accept,
+    // which counts as the user gesture WKWebView needs to release the
+    // popup. We keep promptBeforeOpen: false on Web/Windows so the
+    // existing one-click UX is unchanged.
     const isMac = Office.context.platform === Office.PlatformType.Mac;
-    log(`platform=${Office.context.platform} → displayInIframe=${isMac}`);
+    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
 
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      // promptBeforeOpen: false suppresses the "PostGuard is opening
-      // another window" confirmation. Honored because the dialog URL is
-      // on the same origin as the add-in's source location. Requires
-      // Mailbox 1.9 (we require 1.12 in VersionOverridesV1_1).
-      { height: heightPct, width: widthPct, displayInIframe: isMac, promptBeforeOpen: false },
+      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,17 +236,11 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
-// Floor the dialog size at 30% of the screen. The popup blocker — fixed
-// via promptBeforeOpen — was the real cause of the launchevent dialog
-// failures, but on a 3440×1440 ultrawide our 300px target still resolves
-// to 9% width, which renders the Yivi QR uncomfortably small even when
-// the host accepts it. 30% gives the dialog enough room for the QR plus
-// title and Cancel button across screen sizes.
-const MIN_DIALOG_PCT = 30;
-
 function pctOfScreen(targetPx: number, screenPx: number): number {
+  // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
+  // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
+  return Math.min(99, Math.max(1, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,40 +263,21 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // New Outlook for Mac (WKWebView) blocks popup windows from a
-    // launchevent runtime, and iframe mode (displayInIframe: true) had
-    // no parent surface to render into. The remaining lever is the
-    // Office-level "open another window" prompt: with promptBeforeOpen:
-    // true Office shows its own confirmation that the user can accept,
-    // which counts as the user gesture WKWebView needs to release the
-    // popup. We keep promptBeforeOpen: false on Web/Windows so the
-    // existing one-click UX is unchanged.
-    // Verbose platform diagnostics so we can confirm in the Smart Alert
-    // that isMac is actually evaluating true on Outlook for Mac. The
-    // launchevent runtime may report platform via a different shape
-    // than the taskpane (Office.PlatformType might even be undefined),
-    // so log every relevant value rather than guessing.
-    const rawPlatform = Office.context.platform;
-    const platformTypeMac = Office.PlatformType?.Mac;
-    const isMac = rawPlatform === platformTypeMac;
-    const platformDebug =
-      `rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
-      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
-      `Office.PlatformType=${JSON.stringify(Office.PlatformType ?? null)} ` +
-      `isMac=${isMac} promptBeforeOpen=${isMac}`;
-    log(platformDebug);
-
+    // promptBeforeOpen MUST stay at the default (true). The Office-level
+    // "PostGuard is opening another window" confirmation is what gives
+    // displayDialogAsync a user gesture; without it, browsers and Mac's
+    // WKWebView silently block the popup the dialog needs. Web users had
+    // it working previously only because they had already clicked Allow
+    // once and Safari remembered. The launchevent context counts as a
+    // background event, not a user-initiated action, so we cannot suppress
+    // the prompt the way a taskpane button click could.
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
+      { height: heightPct, width: widthPct, displayInIframe: false },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(
-            new Error(
-              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
-            )
-          );
+          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
           return;
         }
         const dialog = asyncResult.value;

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,17 +236,11 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
-// Floor the dialog size at 30% of the screen. Office.js docs claim the
-// valid range is 1–99, but in practice Outlook hosts (Web on ultrawide
-// monitors, New Outlook for Mac) reject very small percentages with no
-// further detail — Web returns `code=12011 BlockedNavigation`, Mac
-// surfaces it as the generic E_FAIL. 30% comfortably clears whatever
-// the actual minimum is across hosts and still fits a 250-300px QR.
-const MIN_DIALOG_PCT = 30;
-
 function pctOfScreen(targetPx: number, screenPx: number): number {
+  // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
+  // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
+  return Math.min(99, Math.max(1, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,17 +263,21 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
-    // promptBeforeOpen MUST stay at its default (true). The Office-level
-    // "PostGuard is opening another window" confirmation is the user
-    // gesture that releases the popup the dialog needs — without it Mac
-    // WKWebView and any Web browser without a previously-granted popup
-    // permission silently block the popup with no recoverable error.
-    // Suppressing it (false) appears to work on returning Safari users
-    // whose host permission is cached, but breaks every fresh session
-    // and every Mac install.
+    // promptBeforeOpen branches on platform. New Outlook for Mac
+    // (WKWebView) has no per-site popup-permission UI, so the Office-
+    // level "PostGuard is opening another window" prompt is the only
+    // user gesture that releases the popup — keep it on (true). On
+    // Web/Windows the host browser exposes its own popup permission;
+    // once granted, the popup opens with no extra prompt needed, so
+    // suppressing the Office prompt (false) gives a one-click send.
+    // First-time Web users may need to allow popups for the host once
+    // via the browser's native indicator.
+    const isMac = Office.context.platform === Office.PlatformType.Mac;
+    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
+
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
-      { height: heightPct, width: widthPct, displayInIframe: false },
+      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: isMac },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -271,8 +271,20 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     // which counts as the user gesture WKWebView needs to release the
     // popup. We keep promptBeforeOpen: false on Web/Windows so the
     // existing one-click UX is unchanged.
-    const isMac = Office.context.platform === Office.PlatformType.Mac;
-    log(`platform=${Office.context.platform} → promptBeforeOpen=${isMac}`);
+    // Verbose platform diagnostics so we can confirm in the Smart Alert
+    // that isMac is actually evaluating true on Outlook for Mac. The
+    // launchevent runtime may report platform via a different shape
+    // than the taskpane (Office.PlatformType might even be undefined),
+    // so log every relevant value rather than guessing.
+    const rawPlatform = Office.context.platform;
+    const platformTypeMac = Office.PlatformType?.Mac;
+    const isMac = rawPlatform === platformTypeMac;
+    const platformDebug =
+      `rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
+      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
+      `Office.PlatformType=${JSON.stringify(Office.PlatformType ?? null)} ` +
+      `isMac=${isMac} promptBeforeOpen=${isMac}`;
+    log(platformDebug);
 
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
@@ -280,7 +292,11 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error(`displayDialogAsync failed: ${asyncResult.error?.message}`));
+          reject(
+            new Error(
+              `displayDialogAsync failed: ${asyncResult.error?.message} | ${platformDebug}`
+            )
+          );
           return;
         }
         const dialog = asyncResult.value;

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -263,13 +263,24 @@ function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> {
     const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
     log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
 
+    // New Outlook for Mac (WKWebView) blocks popup windows from a
+    // launchevent runtime with no per-site override available to the
+    // user, which makes the popup-mode dialog (displayInIframe: false)
+    // fail with the misleading "different security zones" error 12011 —
+    // surfaced as a generic E_FAIL on Mac. iframe mode bypasses the
+    // popup blocker. It is reportedly broken in Outlook on the web
+    // (office-js#2129) so we keep popup mode there. Detect Mac via
+    // Office.context.platform and branch the option.
+    const isMac = Office.context.platform === Office.PlatformType.Mac;
+    log(`platform=${Office.context.platform} → displayInIframe=${isMac}`);
+
     Office.context.ui.displayDialogAsync(
       YIVI_DIALOG_URL,
       // promptBeforeOpen: false suppresses the "PostGuard is opening
       // another window" confirmation. Honored because the dialog URL is
       // on the same origin as the add-in's source location. Requires
       // Mailbox 1.9 (we require 1.12 in VersionOverridesV1_1).
-      { height: heightPct, width: widthPct, displayInIframe: false, promptBeforeOpen: false },
+      { height: heightPct, width: widthPct, displayInIframe: isMac, promptBeforeOpen: false },
       (asyncResult) => {
         log(`displayDialogAsync status=${asyncResult.status}`);
         if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -236,11 +236,17 @@ const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
 // always closes itself.
 const DEBUG_KEEP_DIALOG_OPEN = false;
 
+// Floor the dialog size at 30% of the screen. Office.js docs claim the
+// valid range is 1–99, but in practice Outlook hosts (Web on ultrawide
+// monitors, New Outlook for Mac) reject very small percentages with no
+// further detail — Web returns `code=12011 BlockedNavigation`, Mac
+// surfaces it as the generic E_FAIL. 30% comfortably clears whatever
+// the actual minimum is across hosts and still fits a 250-300px QR.
+const MIN_DIALOG_PCT = 30;
+
 function pctOfScreen(targetPx: number, screenPx: number): number {
-  // displayDialogAsync clamps to [1, 99]. Round up so we don't drop
-  // below the QR's minimum useful size on huge monitors.
   const pct = Math.ceil((targetPx / screenPx) * 100);
-  return Math.min(99, Math.max(1, pct));
+  return Math.min(99, Math.max(MIN_DIALOG_PCT, pct));
 }
 
 // Opens the Yivi dialog with an encrypt-request payload and waits for

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -558,6 +558,16 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
 log("script loaded");
 Office.onReady((info) => {
   log(`Office.onReady fired; host=${info?.host} platform=${info?.platform}`);
+  // Eager platform diagnostic so DevTools shows it without waiting for
+  // a Send + handler dispatch + dialog open. Same logic that decides
+  // promptBeforeOpen inside runEncryptDialog.
+  const rawPlatform = Office.context?.platform;
+  const platformTypeMac = Office.PlatformType?.Mac;
+  log(
+    `platform check: rawPlatform=${String(rawPlatform)} (typeof=${typeof rawPlatform}) ` +
+      `Office.PlatformType.Mac=${String(platformTypeMac)} (typeof=${typeof platformTypeMac}) ` +
+      `isMac=${rawPlatform === platformTypeMac}`
+  );
   Office.actions.associate("onMessageSendHandler", onMessageSendHandler);
   log("handler associated");
 });

--- a/src/yivi-dialog/yivi-dialog.html
+++ b/src/yivi-dialog/yivi-dialog.html
@@ -16,6 +16,11 @@
       <section class="pg-view">
         <h2 id="pg-dlg-title" class="pg-section-title">PostGuard</h2>
         <p id="pg-dlg-subtitle" class="pg-subtitle">Preparing encryption…</p>
+        <aside id="pg-dlg-safari-tip" class="pg-info" hidden>
+          Safari blocks this window by default. Allow popups for this
+          site in Safari → Settings → Websites → Pop-ups → Allow to
+          skip the confirmation on every send.
+        </aside>
         <div id="yivi-web-form" class="pg-yivi-host"></div>
         <div id="pg-dlg-error" class="pg-error" hidden></div>
         <div class="pg-button-row pg-button-row-end">

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -207,6 +207,19 @@ function handlePayload(msg: DialogMessage): void {
 Office.onReady(() => {
   log("Office.onReady fired");
 
+  // Show a one-time hint in Safari pointing at the per-site popup
+  // setting. Match Safari only — not WKWebView (Outlook for Mac), where
+  // no such setting is reachable. Safari's UA includes "Safari/<ver>"
+  // after AppleWebKit; WKWebView omits the Safari token. Chromium
+  // browsers spoof AppleWebKit but include "Chrome" or "Edg".
+  const ua = navigator.userAgent || "";
+  const isSafari =
+    /AppleWebKit/.test(ua) && /Safari\//.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
+  if (isSafari) {
+    const tip = document.getElementById("pg-dlg-safari-tip");
+    if (tip) tip.hidden = false;
+  }
+
   const cancelBtn = document.getElementById("pg-dlg-cancel") as HTMLButtonElement | null;
   if (cancelBtn) {
     cancelBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
Final fix for the OnMessageSend `displayDialogAsync` failures we've been chasing across Web, Mac, and ultrawide displays. Tested working in:

- **Outlook on the web** (Safari, including ultrawide displays).
- **New Outlook for Mac**.

Two changes on top of the AppDomains allowlist (#23):

1. **`promptBeforeOpen` defaults to `true` on every platform.** This was the root cause that took the longest to surface. The Office-level "PostGuard is opening another window" confirmation isn't UX noise — it's the *user gesture* `displayDialogAsync` needs to release the popup through the browser/WKWebView popup blocker. Suppressing it (`promptBeforeOpen: false`) only works for browser sessions that have already granted the Outlook host popup permission; fresh Web sessions and every Mac install silently fail without it. Cost: one extra click per send. Worth it.
2. **`MIN_DIALOG_PCT = 30`.** A 300×520 px dialog target on a 3440×1440 ultrawide resolves to 9% width, which renders the Yivi QR uncomfortably small. Floor at 30% so the QR stays usable across screen sizes.

## What we tried that didn't work, kept in the trail

The PR has a long debug history because we kept misattributing the failure mode:

- `displayInIframe: true` on Mac — no parent surface in the launchevent runtime to host an iframe.
- `promptBeforeOpen: isMac` — looked like it worked on Web only because the test session had cached popup permission from earlier runs; broke as soon as that cache cleared. Same dynamic explained why Mac-only attempts kept failing too.

Squash on merge to collapse the trail.

## Test plan
- [x] Outlook on the web (Safari, ultrawide) — encrypt-on-send → Office prompt → Allow → Yivi dialog opens.
- [x] New Outlook for Mac — encrypt-on-send → Office prompt → Allow → Yivi dialog opens.
- [ ] Sideload via `npm start` (localhost) — same prompt-then-dialog flow.
- [ ] Production smoke test once staging passes.