### PR TITLE
ci: attach production manifest.xml to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,27 @@ jobs:
             POSTGUARD_WEBSITE_URL=${{ env.POSTGUARD_WEBSITE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Attach the production-built manifest.xml to the GitHub Release so
+      # admins centralizing deployment have a stable, versioned URL to
+      # sideload from instead of pulling the Docker image or relying on
+      # whatever the running addin host is currently serving.
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build manifest with production URL
+        env:
+          ADDIN_PUBLIC_URL: https://${{ env.ADDIN_HOST }}/
+          PKG_URL: ${{ env.PKG_URL }}
+          CRYPTIFY_URL: ${{ env.CRYPTIFY_URL }}
+          POSTGUARD_WEBSITE_URL: ${{ env.POSTGUARD_WEBSITE_URL }}
+        run: npm run build
+
+      - name: Upload manifest.xml to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/manifest.xml --clobber


### PR DESCRIPTION
## Summary
After release-please cuts a release and \`build-release\` pushes the versioned Docker image, build the manifest one more time with the production \`ADDIN_PUBLIC_URL\` and upload it to the GitHub Release as \`manifest.xml\`.

Today the only ways to get a production manifest are:
- Live URL: \`https://addin.postguard.eu/manifest.xml\` — moves with each deploy.
- Pull \`ghcr.io/encryption4all/postguard-outlook-addon:vX.Y.Z\` and extract.

After this change, every Release page also has a stable, version-pinned \`manifest.xml\` asset — handy for offline sideloading, archival, audit trails, and admins centralizing deployment via the Microsoft 365 Admin Center.

## Implementation
- Adds \`actions/setup-node@v5\` + \`npm ci\` + \`npm run build\` to the existing \`build-release\` job.
- Build runs with the same env vars as the Docker image so the bundled \`dist/manifest.xml\` matches what the image serves.
- \`gh release upload --clobber\` so re-runs overwrite cleanly.

## Test plan
- [ ] Trigger a release-please merge and confirm \`manifest.xml\` appears under the Release's Assets.
- [ ] Sanity-check the asset's content: \`SourceLocation\` URLs point at \`https://addin.postguard.eu/...\`.
- [ ] Confirm \`build-edge\` (the non-release path) is unchanged — still skips this manifest-upload step.