### PR TITLE
fix(launchevent): always prompt on Apple WebKit; drop retry and Safari hint

### DIFF
--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -279,56 +279,25 @@ async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> 
     displayInIframe: false,
   };
 
-  // Outlook for Mac (the native app, not Outlook on the web in Safari)
-  // has no per-site popup-permission UI reachable from a launchevent
-  // runtime. The optimistic-then-retry pattern below always loses its
-  // first attempt there and just adds a wasted round-trip, so go
-  // straight to promptBeforeOpen: true. Safari users on Outlook on the
-  // web still benefit from the optimistic path because they can grant
-  // popup permission once and get a one-click send afterwards.
-  const isOutlookForMac = Office.context.platform === Office.PlatformType.Mac;
-  log(`platform=${Office.context.platform} isOutlookForMac=${isOutlookForMac}`);
+  // promptBeforeOpen branches on rendering engine, not Office's
+  // platform enum. Apple WebKit — Safari and the WKWebView that New
+  // Outlook for Mac runs on — silently blocks popups opened from a
+  // launchevent runtime, so the Office-level "PostGuard is opening
+  // another window" confirmation has to fire there: the user's click
+  // on Allow is the gesture WKWebView needs to release the popup.
+  // Blink (Chrome/Edge) and Gecko (Firefox) handle background popups
+  // without intervention, so we skip the prompt for a one-click send.
+  // Office.context.platform reports "OfficeOnline" for every browser
+  // on the web so we match on UA.
+  const ua = navigator.userAgent || "";
+  const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
+  log(`platform=${Office.context.platform} isAppleWebKit=${isAppleWebKit}`);
 
-  let dialog: Office.Dialog;
-  if (isOutlookForMac) {
-    log("Outlook for Mac → displayDialogAsync with promptBeforeOpen=true");
-    dialog = await openDialogAsync(YIVI_DIALOG_URL, {
-      ...baseOptions,
-      promptBeforeOpen: true,
-    });
-    log("dialog opened (Mac, prompt)");
-  } else {
-    // Try without Office's "open another window" prompt first.
-    // Browsers that allow popups from the Outlook host (Chrome/Edge/
-    // Firefox by default, and Safari once the user has granted
-    // permission once) get a one-click send. If the attempt fails —
-    // typically Apple WebKit silently blocking the popup — retry with
-    // promptBeforeOpen: true so the Office prompt fires and the user's
-    // click on Allow becomes the gesture that releases the popup. The
-    // dialog itself shows a Safari-only hint pointing at Settings →
-    // Websites → Pop-ups so the user can skip the prompt thereafter.
-    try {
-      log("displayDialogAsync attempt 1: promptBeforeOpen=false");
-      dialog = await openDialogAsync(YIVI_DIALOG_URL, {
-        ...baseOptions,
-        promptBeforeOpen: false,
-      });
-      log("dialog opened (no prompt)");
-    } catch (e1) {
-      const msg1 = (e1 as { message?: string })?.message ?? String(e1);
-      log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
-      try {
-        dialog = await openDialogAsync(YIVI_DIALOG_URL, {
-          ...baseOptions,
-          promptBeforeOpen: true,
-        });
-        log("dialog opened (after prompt)");
-      } catch (e2) {
-        const msg2 = (e2 as { message?: string })?.message ?? String(e2);
-        throw new Error(`displayDialogAsync failed: ${msg2}`);
-      }
-    }
-  }
+  const dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+    ...baseOptions,
+    promptBeforeOpen: isAppleWebKit,
+  });
+  log(`dialog opened (promptBeforeOpen=${isAppleWebKit})`);
 
   return new Promise((resolve, reject) => {
     const inbound = new ChunkAssembler();

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -279,36 +279,54 @@ async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> 
     displayInIframe: false,
   };
 
-  // Try to open the dialog without Office's "open another window"
-  // prompt first. Browsers that allow popups from the Outlook host
-  // (Chrome/Edge/Firefox by default, and Safari once the user has
-  // granted permission once) get a one-click send. If that attempt
-  // fails — typically because Apple WebKit blocked the popup with no
-  // surfaced UI — retry with promptBeforeOpen: true so the Office
-  // prompt fires and the user's click on Allow becomes the gesture
-  // that releases the popup. The dialog itself shows a Safari-only
-  // hint pointing at Settings → Websites → Pop-ups so the user can
-  // skip the prompt on subsequent sends.
+  // Outlook for Mac (the native app, not Outlook on the web in Safari)
+  // has no per-site popup-permission UI reachable from a launchevent
+  // runtime. The optimistic-then-retry pattern below always loses its
+  // first attempt there and just adds a wasted round-trip, so go
+  // straight to promptBeforeOpen: true. Safari users on Outlook on the
+  // web still benefit from the optimistic path because they can grant
+  // popup permission once and get a one-click send afterwards.
+  const isOutlookForMac = Office.context.platform === Office.PlatformType.Mac;
+  log(`platform=${Office.context.platform} isOutlookForMac=${isOutlookForMac}`);
+
   let dialog: Office.Dialog;
-  try {
-    log("displayDialogAsync attempt 1: promptBeforeOpen=false");
+  if (isOutlookForMac) {
+    log("Outlook for Mac → displayDialogAsync with promptBeforeOpen=true");
     dialog = await openDialogAsync(YIVI_DIALOG_URL, {
       ...baseOptions,
-      promptBeforeOpen: false,
+      promptBeforeOpen: true,
     });
-    log("dialog opened (no prompt)");
-  } catch (e1) {
-    const msg1 = (e1 as { message?: string })?.message ?? String(e1);
-    log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
+    log("dialog opened (Mac, prompt)");
+  } else {
+    // Try without Office's "open another window" prompt first.
+    // Browsers that allow popups from the Outlook host (Chrome/Edge/
+    // Firefox by default, and Safari once the user has granted
+    // permission once) get a one-click send. If the attempt fails —
+    // typically Apple WebKit silently blocking the popup — retry with
+    // promptBeforeOpen: true so the Office prompt fires and the user's
+    // click on Allow becomes the gesture that releases the popup. The
+    // dialog itself shows a Safari-only hint pointing at Settings →
+    // Websites → Pop-ups so the user can skip the prompt thereafter.
     try {
+      log("displayDialogAsync attempt 1: promptBeforeOpen=false");
       dialog = await openDialogAsync(YIVI_DIALOG_URL, {
         ...baseOptions,
-        promptBeforeOpen: true,
+        promptBeforeOpen: false,
       });
-      log("dialog opened (after prompt)");
-    } catch (e2) {
-      const msg2 = (e2 as { message?: string })?.message ?? String(e2);
-      throw new Error(`displayDialogAsync failed: ${msg2}`);
+      log("dialog opened (no prompt)");
+    } catch (e1) {
+      const msg1 = (e1 as { message?: string })?.message ?? String(e1);
+      log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
+      try {
+        dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+          ...baseOptions,
+          promptBeforeOpen: true,
+        });
+        log("dialog opened (after prompt)");
+      } catch (e2) {
+        const msg2 = (e2 as { message?: string })?.message ?? String(e2);
+        throw new Error(`displayDialogAsync failed: ${msg2}`);
+      }
     }
   }
 

--- a/src/yivi-dialog/yivi-dialog.html
+++ b/src/yivi-dialog/yivi-dialog.html
@@ -16,11 +16,6 @@
       <section class="pg-view">
         <h2 id="pg-dlg-title" class="pg-section-title">PostGuard</h2>
         <p id="pg-dlg-subtitle" class="pg-subtitle">Preparing encryption…</p>
-        <aside id="pg-dlg-safari-tip" class="pg-info" hidden>
-          Safari blocks this window by default. Allow popups for this
-          site in Safari → Settings → Websites → Pop-ups → Allow to
-          skip the confirmation on every send.
-        </aside>
         <div id="yivi-web-form" class="pg-yivi-host"></div>
         <div id="pg-dlg-error" class="pg-error" hidden></div>
         <div class="pg-button-row pg-button-row-end">

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -207,19 +207,6 @@ function handlePayload(msg: DialogMessage): void {
 Office.onReady(() => {
   log("Office.onReady fired");
 
-  // Show a one-time hint in Safari pointing at the per-site popup
-  // setting. Match Safari only — not WKWebView (Outlook for Mac), where
-  // no such setting is reachable. Safari's UA includes "Safari/<ver>"
-  // after AppleWebKit; WKWebView omits the Safari token. Chromium
-  // browsers spoof AppleWebKit but include "Chrome" or "Edg".
-  const ua = navigator.userAgent || "";
-  const isSafari =
-    /AppleWebKit/.test(ua) && /Safari\//.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
-  if (isSafari) {
-    const tip = document.getElementById("pg-dlg-safari-tip");
-    if (tip) tip.hidden = false;
-  }
-
   const cancelBtn = document.getElementById("pg-dlg-cancel") as HTMLButtonElement | null;
   if (cancelBtn) {
     cancelBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
Refines the OnMessageSend popup-handling shipped in #24. Every Apple WebKit client — Safari on the web *and* Outlook for Mac — silently blocks dialog popups, so we now show Office's confirmation prompt there unconditionally. Single \`displayDialogAsync\` per send, no try-then-retry, no Safari-specific hint inside the dialog.

## What changes vs. main

| Client | Before (#24) | After |
|---|---|---|
| Safari on the web | Try without prompt → retry with prompt + show inline hint | Single attempt with prompt |
| Outlook for Mac | Try without prompt → retry with prompt | Single attempt with prompt |
| Chrome / Edge / Firefox / Outlook on Windows | Try without prompt → succeed (one-click) | Same — one-click |

The retry flow served its purpose during diagnosis but adds a wasted round-trip on every WebKit send. The hint inside the dialog only mattered if Safari users could opt out of the recurring prompt — they can't, because we'd still hit the optimistic attempt's silent fail and still need the user gesture from Allow.

## Implementation
- \`launchevent.ts\`: detect Apple WebKit via UA (\`/AppleWebKit/.test(ua) && !/Chrome|Edg|OPR\\//.test(ua)\`), set \`promptBeforeOpen: isAppleWebKit\`, single \`displayDialogAsync\` call.
- \`yivi-dialog.html\`: remove the \`<aside id="pg-dlg-safari-tip">\` element.
- \`yivi-dialog.ts\`: remove the Safari-only hint-unhide block from \`Office.onReady\`.

## Test plan
- [ ] **Outlook for Mac**: send → Office prompt → Allow → dialog opens. Single \`displayDialogAsync\` call in the launchevent log.
- [ ] **Outlook on the web (Safari)**: send → Office prompt → Allow → dialog opens. No inline hint inside the dialog.
- [ ] **Outlook on the web (Chrome / Edge / Firefox)**: send → no prompt → dialog opens directly. One-click.
- [ ] **Outlook on Windows**: same as Chrome — one-click.