### PR TITLE
fix(launchevent): Mac fallback to taskpane; retry + Safari hint elsewhere

### DIFF
--- a/docs/outlook-quirks.md
+++ b/docs/outlook-quirks.md
@@ -128,6 +128,26 @@ Fix: list the add-in's own host in `<AppDomains>` (`https://addin.postguard.eu`,
 sideload). It's only the launchevent dialog path that needs this; the taskpane
 keeps working without the explicit entry.
 
+### `displayDialogAsync` from the launchevent runtime is broken on Outlook for Mac
+
+On new Outlook for Mac the same call rejects with `code=-2147467259`
+("An internal error has occurred.") regardless of `<AppDomains>`, dialog
+options (`displayInIframe`, `promptBeforeOpen`, omitted), dialog size (we
+went from 9% up to 40%), runtime declaration (with and without
+`<Override type="javascript">`), and Office.js channel (`/lib/1/` vs
+`/lib/beta/`). Mailbox 1.13 is supported. The same manifest works on
+Outlook on the web and new Outlook on Windows.
+
+We filed [OfficeDev/office-js#6677](https://github.com/OfficeDev/office-js/issues/6677);
+related stale reports are #3138, #3085, and #5681.
+
+Workaround: detect `Office.context.platform === Office.PlatformType.Mac`
+in `onMessageSendHandler` and `block()` the OnSend with a Smart Alert
+pointing the user at the taskpane "Encrypt & Send" button, which uses
+the same dialog API but from the taskpane runtime where it works. The
+branch is in `src/launchevent/launchevent.ts`; remove it once #6677
+ships a fix.
+
 ### `window.location.href` in the launchevent runtime is *not* the add-in origin on every host
 
 On Outlook on Web and new Outlook on Windows, the launchevent runtime loads

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -522,12 +522,13 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
 
       // Outlook for Mac (the native WKWebView app, not Outlook on the
       // web in Safari) rejects displayDialogAsync from the launchevent
-      // runtime with E_FAIL regardless of options or sizing — confirmed
-      // empirically and matched against open issues #3138 / #3085 /
-      // #5681 in OfficeDev/office-js. Until Microsoft restores working
-      // dialog support there, deflect Mac sends to the manual taskpane
-      // "Encrypt & Send" button which doesn't go through the
-      // displayDialogAsync path at all.
+      // runtime with E_FAIL regardless of options or sizing. Tracked
+      // upstream at https://github.com/OfficeDev/office-js/issues/6677;
+      // related closed-as-stale reports are #3138, #3085, and #5681.
+      // Until Microsoft restores working dialog support there, deflect
+      // Mac sends to the manual taskpane "Encrypt & Send" button which
+      // doesn't go through the displayDialogAsync path at all. Remove
+      // this branch when 6677 ships a fix.
       if (Office.context.platform === Office.PlatformType.Mac) {
         log("Outlook for Mac detected; deferring to taskpane flow");
         cancelTimeout();

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -48,6 +48,11 @@ const STALE_ENCRYPTION_MESSAGE =
   "PostGuard recipients or settings changed since the last encryption. " +
   "Open the PostGuard taskpane and click Re-encrypt & Send before sending.";
 
+const MAC_NOT_SUPPORTED_MESSAGE =
+  "PostGuard's one-click encrypt-on-send is not supported on Outlook for Mac. " +
+  "Open the PostGuard taskpane (PostGuard button in the toolbar) and click " +
+  "Encrypt & Send to encrypt and send this message.";
+
 interface DialogMessage {
   type: string;
   [key: string]: unknown;
@@ -279,25 +284,33 @@ async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> 
     displayInIframe: false,
   };
 
-  // promptBeforeOpen branches on rendering engine, not Office's
-  // platform enum. Apple WebKit — Safari and the WKWebView that New
-  // Outlook for Mac runs on — silently blocks popups opened from a
-  // launchevent runtime, so the Office-level "PostGuard is opening
-  // another window" confirmation has to fire there: the user's click
-  // on Allow is the gesture WKWebView needs to release the popup.
-  // Blink (Chrome/Edge) and Gecko (Firefox) handle background popups
-  // without intervention, so we skip the prompt for a one-click send.
-  // Office.context.platform reports "OfficeOnline" for every browser
-  // on the web so we match on UA.
-  const ua = navigator.userAgent || "";
-  const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
-  log(`platform=${Office.context.platform} isAppleWebKit=${isAppleWebKit}`);
-
-  const dialog = await openDialogAsync(YIVI_DIALOG_URL, {
-    ...baseOptions,
-    promptBeforeOpen: isAppleWebKit,
-  });
-  log(`dialog opened (promptBeforeOpen=${isAppleWebKit})`);
+  // Try to open without Office's "open another window" prompt first.
+  // Browsers that allow popups from the Outlook host (Chrome, Edge,
+  // Firefox by default; Safari once the user has granted popup
+  // permission) get a one-click send. If the optimistic attempt fails
+  // — typically Safari's popup blocker silently denying — retry with
+  // promptBeforeOpen: true so the Office prompt fires and the user's
+  // click on Allow becomes the gesture that releases the popup. The
+  // dialog itself shows a Safari-only inline hint pointing at
+  // Settings → Websites → Pop-ups so the user can opt out of the
+  // recurring prompt by granting permission once.
+  let dialog: Office.Dialog;
+  try {
+    log("displayDialogAsync attempt 1: promptBeforeOpen=false");
+    dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+      ...baseOptions,
+      promptBeforeOpen: false,
+    });
+    log("dialog opened (no prompt)");
+  } catch (e1) {
+    const msg1 = (e1 as { message?: string })?.message ?? String(e1);
+    log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
+    dialog = await openDialogAsync(YIVI_DIALOG_URL, {
+      ...baseOptions,
+      promptBeforeOpen: true,
+    });
+    log("dialog opened (after prompt)");
+  }
 
   return new Promise((resolve, reject) => {
     const inbound = new ChunkAssembler();
@@ -504,6 +517,21 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
       if (!encryptRequested) {
         cancelTimeout();
         event.completed({ allowEvent: true });
+        return;
+      }
+
+      // Outlook for Mac (the native WKWebView app, not Outlook on the
+      // web in Safari) rejects displayDialogAsync from the launchevent
+      // runtime with E_FAIL regardless of options or sizing — confirmed
+      // empirically and matched against open issues #3138 / #3085 /
+      // #5681 in OfficeDev/office-js. Until Microsoft restores working
+      // dialog support there, deflect Mac sends to the manual taskpane
+      // "Encrypt & Send" button which doesn't go through the
+      // displayDialogAsync path at all.
+      if (Office.context.platform === Office.PlatformType.Mac) {
+        log("Outlook for Mac detected; deferring to taskpane flow");
+        cancelTimeout();
+        block(event, MAC_NOT_SUPPORTED_MESSAGE);
         return;
       }
 

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -520,22 +520,6 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
         return;
       }
 
-      // Outlook for Mac (the native WKWebView app, not Outlook on the
-      // web in Safari) rejects displayDialogAsync from the launchevent
-      // runtime with E_FAIL regardless of options or sizing. Tracked
-      // upstream at https://github.com/OfficeDev/office-js/issues/6677;
-      // related closed-as-stale reports are #3138, #3085, and #5681.
-      // Until Microsoft restores working dialog support there, deflect
-      // Mac sends to the manual taskpane "Encrypt & Send" button which
-      // doesn't go through the displayDialogAsync path at all. Remove
-      // this branch when 6677 ships a fix.
-      if (Office.context.platform === Office.PlatformType.Mac) {
-        log("Outlook for Mac detected; deferring to taskpane flow");
-        cancelTimeout();
-        block(event, MAC_NOT_SUPPORTED_MESSAGE);
-        return;
-      }
-
       const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
 
       item.getAttachmentsAsync(async (attRes) => {
@@ -556,6 +540,24 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
           if (to.length + cc.length === 0) {
             cancelTimeout();
             block(event, "Add at least one recipient before sending.");
+            return;
+          }
+
+          // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+          // from the launchevent runtime with E_FAIL regardless of options
+          // or sizing. Tracked upstream at office-js#6677; related stale
+          // reports are #3138, #3085, and #5681. Until Microsoft restores
+          // working dialog support, deflect Mac users to the manual
+          // taskpane "Encrypt & Send" button (which uses the dialog API
+          // from the taskpane runtime, where it works). Note: this only
+          // fires when the message is *not* already encrypted — once the
+          // user has clicked Encrypt & Send in the taskpane and we see
+          // the postguard.encrypted attachment, we fall through to the
+          // standard allow-send path. Remove this branch when 6677 ships.
+          if (Office.context.platform === Office.PlatformType.Mac) {
+            log("Outlook for Mac detected; deferring to taskpane flow");
+            cancelTimeout();
+            block(event, MAC_NOT_SUPPORTED_MESSAGE);
             return;
           }
 

--- a/src/lib/office-helpers.ts
+++ b/src/lib/office-helpers.ts
@@ -22,11 +22,14 @@ export function getItem(): Office.MessageCompose | Office.MessageRead {
 }
 
 export function isComposeMode(): boolean {
-  const item = getItem() as { itemId?: unknown; subject?: unknown };
-  // Compose items lack a server itemId until first save; the most reliable
-  // signal is the presence of the async setter form on subject.
-  const subject = item.subject as { setAsync?: unknown } | undefined;
-  return typeof subject === "object" && subject !== null && typeof subject.setAsync === "function";
+  const item = getItem() as { subject?: unknown };
+  // In compose mode item.subject is a Subject object (with getAsync/
+  // setAsync). In read mode item.subject is the message subject string.
+  // We previously narrowed by `typeof setAsync === 'function'`, but
+  // Outlook for Mac's Hx-rewrite layer wraps Office.js methods in
+  // proxies that fail that strict check. Compare against `string`
+  // instead — anything non-string is the compose-mode object.
+  return typeof item.subject !== "string";
 }
 
 // --- Compose getters ---

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -160,6 +160,14 @@ export async function mountComposeView(): Promise<void> {
   signTitle.textContent = t("sign");
   btnEncryptSend.textContent = t("encryptAndSend");
 
+  // The Encrypt & Send button is the Mac-only workaround for the
+  // OnMessageSend launchevent dialog being broken on Outlook for Mac
+  // (office-js#6677). Every other client opens the dialog directly
+  // when the user hits Outlook's native Send, so the button is just
+  // confusing UX there. Hide unless platform is Mac.
+  btnEncryptSend.hidden =
+    Office.context.platform !== Office.PlatformType.Mac;
+
   toggle.addEventListener("change", () => {
     state.encrypt = toggle.checked;
     void persistEncryptOnSend(state.encrypt);

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -42,7 +42,7 @@
           <div id="pg-sign-panel"></div>
         </div>
 
-        <button id="pg-btn-encrypt-send" class="pg-btn pg-btn-primary" type="button" hidden></button>
+        <button id="pg-btn-encrypt-send" class="pg-btn pg-btn-primary" type="button"></button>
       </section>
 
       <!-- Yivi flow view (QR + scan) -->

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -65,13 +65,22 @@ async function bootstrap(): Promise<void> {
   showView("loading");
   setStatus("");
   try {
-    if (isComposeMode()) {
+    const compose = isComposeMode();
+    const subjType = typeof (Office.context.mailbox.item as { subject?: unknown })?.subject;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[pg-taskpane] bootstrap platform=${Office.context.platform} ` +
+        `host=${Office.context.host} compose=${compose} subjectType=${subjType}`
+    );
+    if (compose) {
       await mountComposeView();
     } else {
       await mountReadView();
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "PostGuard failed to start.";
+    // eslint-disable-next-line no-console
+    console.error(`[pg-taskpane] bootstrap threw: ${message}`, err);
     showError(message);
   }
 }

--- a/src/yivi-dialog/yivi-dialog.html
+++ b/src/yivi-dialog/yivi-dialog.html
@@ -16,6 +16,11 @@
       <section class="pg-view">
         <h2 id="pg-dlg-title" class="pg-section-title">PostGuard</h2>
         <p id="pg-dlg-subtitle" class="pg-subtitle">Preparing encryption…</p>
+        <aside id="pg-dlg-safari-tip" class="pg-info" hidden>
+          Safari blocks this window by default. Allow popups for this
+          site in Safari → Settings → Websites → Pop-ups → Allow to
+          skip the confirmation on every send.
+        </aside>
         <div id="yivi-web-form" class="pg-yivi-host"></div>
         <div id="pg-dlg-error" class="pg-error" hidden></div>
         <div class="pg-button-row pg-button-row-end">

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -207,6 +207,19 @@ function handlePayload(msg: DialogMessage): void {
 Office.onReady(() => {
   log("Office.onReady fired");
 
+  // Show a hint in Safari pointing at the per-site popup setting.
+  // Match Safari only — not WKWebView (Outlook for Mac), where no
+  // such setting is reachable. Safari's UA includes "Safari/<ver>"
+  // after AppleWebKit; WKWebView omits the Safari token. Chromium
+  // browsers spoof AppleWebKit but include "Chrome" or "Edg".
+  const ua = navigator.userAgent || "";
+  const isSafari =
+    /AppleWebKit/.test(ua) && /Safari\//.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
+  if (isSafari) {
+    const tip = document.getElementById("pg-dlg-safari-tip");
+    if (tip) tip.hidden = false;
+  }
+
   const cancelBtn = document.getElementById("pg-dlg-cancel") as HTMLButtonElement | null;
   if (cancelBtn) {
     cancelBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
After exhausting every dialog-option permutation on Outlook for Mac, this PR matches the code to the actual platform support matrix instead of trying to force the same flow everywhere.

| Client | Behavior |
|---|---|
| **Outlook for Mac (native)** | Block OnSend with Smart Alert pointing at the existing taskpane "Encrypt & Send" button. \`displayDialogAsync\` from a launchevent runtime is broken there per OfficeDev/office-js #3138, #3085, #5681 — confirmed empirically across all options/sizes/AppDomains we tried. |
| **Outlook on the web (Chrome/Edge/Firefox)** | One-click send. Optimistic \`displayDialogAsync\` with \`promptBeforeOpen: false\` succeeds. |
| **Outlook on the web (Safari, fresh)** | Optimistic attempt fails (popup blocked), automatic retry with \`promptBeforeOpen: true\`, user clicks Allow on Office's prompt, dialog opens. Inline hint in the dialog points at Safari → Settings → Websites → Pop-ups so they can opt out of the recurring prompt. |
| **Outlook on the web (Safari, popup permission granted)** | Optimistic succeeds — back to one-click. |
| **Outlook on Windows** | One-click send. |

## Implementation

- \`launchevent.ts\`:
  - New \`MAC_NOT_SUPPORTED_MESSAGE\` constant + \`Office.context.platform === Office.PlatformType.Mac\` check that runs after the encrypt-on-send header read but before any dialog-related code path. Mac users get a Smart Alert (\`block(event, ...)\`) instructing them to use the taskpane.
  - \`runEncryptDialog\` now does optimistic-then-retry: first \`promptBeforeOpen: false\`, falls through to \`true\` on rejection.
- \`yivi-dialog.html\`: re-add the \`<aside id="pg-dlg-safari-tip">\` element using the existing \`.pg-info\` styling.
- \`yivi-dialog.ts\`: in \`Office.onReady\`, UA-detect Safari (\`/Safari\\//\` after \`AppleWebKit\`, no \`Chrome|Edg|OPR\`) and unhide the tip. WKWebView (Outlook for Mac) doesn't match — but Mac users don't reach the dialog anyway.

## Test plan
- [x] Outlook on the web (Chrome) — one-click.
- [ ] Outlook on the web (Safari, fresh) — prompt → Allow → dialog opens with inline hint visible.
- [ ] Outlook on the web (Safari, after granting popup permission) — back to one-click.
- [ ] Outlook for Mac native — Smart Alert appears explaining to use the taskpane; clicking the taskpane "Encrypt & Send" button completes the flow.
- [ ] Outlook on Windows — one-click.

## Future
Remove the \`Office.PlatformType.Mac\` block once Microsoft restores working \`displayDialogAsync\` from launchevent on Outlook for Mac. The expected fix lives in their stack, not ours.