### PR TITLE
chore(deps): upgrade TypeScript to ^6.0.3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "office-addins"
-  ],
-  "extends": [
-    "plugin:office-addins/recommended"
-  ]
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint (no errors, no warnings)
+        run: npx eslint -c eslint.config.mjs --max-warnings=0 "src/**/*.{ts,js}"
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      - name: Validate manifest
+        run: npm run validate

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,30 @@
+import officeAddins from "eslint-plugin-office-addins";
+import tsParser from "@typescript-eslint/parser";
+import globals from "globals";
+
+export default [
+  ...officeAddins.configs.recommended,
+  {
+    plugins: {
+      "office-addins": officeAddins,
+    },
+    languageOptions: {
+      parser: tsParser,
+      globals: {
+        ...globals.browser,
+        Office: "readonly",
+        OfficeRuntime: "readonly",
+      },
+    },
+    rules: {
+      // TypeScript already checks this via tsc; ESLint's no-undef doesn't
+      // understand TS ambient types (RequestInit, BlobPart, etc.) or
+      // build-time-replaced identifiers like webpack DefinePlugin's `process`.
+      "no-undef": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "os-browserify": "^0.3.0",
         "process": "^0.11.10",
         "source-map-loader": "^5.0.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "webpack": "^5.106.2",
         "webpack-cli": "^7.0.2",
         "webpack-dev-server": "^5.2.3"
@@ -10599,6 +10599,20 @@
         "eslint": "^9.0.0"
       }
     },
+    "node_modules/eslint-plugin-office-addins/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
@@ -18308,9 +18322,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "os-browserify": "^0.3.0",
     "process": "^0.11.10",
     "source-map-loader": "^5.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "webpack": "^5.106.2",
     "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.2.3"

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,8 +3,6 @@
 // every action goes through the taskpane — but the file must exist and
 // load Office.js so the runtime can mount it.
 
-/* global Office */
-
 Office.onReady(() => {
   // No-op: kept to satisfy the manifest's FunctionFile reference.
 });

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -16,14 +16,7 @@
 // manual taskpane "Encrypt & Send" flow until those are marshalled
 // through to the dialog.
 
-/* global Office */
-
-import {
-  ChunkAssembler,
-  chunkPayload,
-  isChunkMessage,
-  ChunkMessage,
-} from "../lib/dialog-chunk";
+import { ChunkAssembler, chunkPayload, isChunkMessage, ChunkMessage } from "../lib/dialog-chunk";
 import { ADDIN_PUBLIC_URL } from "../lib/pkg-client";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
@@ -39,10 +32,6 @@ const COMPOSE_BUTTON_ID = "postGuardComposeButton";
 // add-in origin, and displayDialogAsync rejects with "An internal error
 // has occurred."
 const YIVI_DIALOG_URL = `${ADDIN_PUBLIC_URL}yivi-dialog.html`;
-
-const NOT_ENCRYPTED_MESSAGE =
-  "PostGuard is on but this message is not encrypted yet. " +
-  "Open the PostGuard taskpane and click Encrypt & Send.";
 
 const STALE_ENCRYPTION_MESSAGE =
   "PostGuard recipients or settings changed since the last encryption. " +
@@ -68,7 +57,6 @@ interface EncryptResult {
 }
 
 function log(msg: string): void {
-  // eslint-disable-next-line no-console
   console.log(`[pg-launchevent] ${msg}`);
 }
 
@@ -103,9 +91,7 @@ function recipientsKey(addresses: Office.EmailAddressDetails[]): string {
     .join(",");
 }
 
-function getRecipientsAsync(
-  recipients: Office.Recipients
-): Promise<Office.EmailAddressDetails[]> {
+function getRecipientsAsync(recipients: Office.Recipients): Promise<Office.EmailAddressDetails[]> {
   return new Promise((resolve) => {
     recipients.getAsync((res) =>
       resolve(res.status === Office.AsyncResultStatus.Succeeded ? res.value : [])
@@ -175,10 +161,7 @@ function getAttachmentContentAsync(
   });
 }
 
-function removeAttachmentAsync(
-  item: Office.MessageCompose,
-  attachmentId: string
-): Promise<void> {
+function removeAttachmentAsync(item: Office.MessageCompose, attachmentId: string): Promise<void> {
   return new Promise((resolve, reject) => {
     item.removeAttachmentAsync(attachmentId, (res) => {
       if (res.status === Office.AsyncResultStatus.Succeeded) resolve();
@@ -250,10 +233,7 @@ function pctOfScreen(targetPx: number, screenPx: number): number {
 
 // Promise wrapper around displayDialogAsync. Resolves with the dialog
 // handle on success, rejects with the Office error otherwise.
-function openDialogAsync(
-  url: string,
-  options: Office.DialogOptions
-): Promise<Office.Dialog> {
+function openDialogAsync(url: string, options: Office.DialogOptions): Promise<Office.Dialog> {
   return new Promise((resolve, reject) => {
     Office.context.ui.displayDialogAsync(url, options, (asyncResult) => {
       if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
@@ -276,7 +256,9 @@ async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> 
   const screenH = window.screen?.height || 1080;
   const widthPct = pctOfScreen(YIVI_DIALOG_TARGET_WIDTH_PX, screenW);
   const heightPct = pctOfScreen(YIVI_DIALOG_TARGET_HEIGHT_PX, screenH);
-  log(`dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`);
+  log(
+    `dialog size: target ${YIVI_DIALOG_TARGET_WIDTH_PX}×${YIVI_DIALOG_TARGET_HEIGHT_PX}px on ${screenW}×${screenH} screen → ${widthPct}%×${heightPct}%`
+  );
 
   const baseOptions: Office.DialogOptions = {
     height: heightPct,
@@ -481,7 +463,9 @@ async function encryptAndApply(
   if (result.attachmentBase64) {
     await addBase64AttachmentAsync(item, POSTGUARD_ENCRYPTED_FILENAME, result.attachmentBase64);
   } else {
-    log(`tier ${result.tier}: skipping local attachment, recipients fetch via uuid=${result.uploadUuid}`);
+    log(
+      `tier ${result.tier}: skipping local attachment, recipients fetch via uuid=${result.uploadUuid}`
+    );
   }
   await setHeadersAsync(item, {
     [HEADER_ENCRYPTED_RECIPIENTS]: recipientsKey([...to, ...cc]),
@@ -502,91 +486,87 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
     return;
   }
 
-  item.internetHeaders.getAsync(
-    [HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS],
-    (hdrRes) => {
-      log(`internetHeaders.getAsync status=${hdrRes.status}`);
-      if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
-        cancelTimeout();
-        event.completed({ allowEvent: true });
-        return;
-      }
-
-      const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
-      log(`encryptRequested=${encryptRequested}`);
-      if (!encryptRequested) {
-        cancelTimeout();
-        event.completed({ allowEvent: true });
-        return;
-      }
-
-      const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
-
-      item.getAttachmentsAsync(async (attRes) => {
-        log(`getAttachmentsAsync status=${attRes.status}`);
-        const attachments =
-          attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
-        const alreadyEncrypted = attachments.some(
-          (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
-        );
-        log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
-
-        const [to, cc] = await Promise.all([
-          getRecipientsAsync(item.to),
-          getRecipientsAsync(item.cc),
-        ]);
-
-        if (!alreadyEncrypted) {
-          if (to.length + cc.length === 0) {
-            cancelTimeout();
-            block(event, "Add at least one recipient before sending.");
-            return;
-          }
-
-          // Outlook for Mac (native WKWebView) rejects displayDialogAsync
-          // from the launchevent runtime with E_FAIL regardless of options
-          // or sizing. Tracked upstream at office-js#6677; related stale
-          // reports are #3138, #3085, and #5681. Until Microsoft restores
-          // working dialog support, deflect Mac users to the manual
-          // taskpane "Encrypt & Send" button (which uses the dialog API
-          // from the taskpane runtime, where it works). Note: this only
-          // fires when the message is *not* already encrypted — once the
-          // user has clicked Encrypt & Send in the taskpane and we see
-          // the postguard.encrypted attachment, we fall through to the
-          // standard allow-send path. Remove this branch when 6677 ships.
-          if (Office.context.platform === Office.PlatformType.Mac) {
-            log("Outlook for Mac detected; deferring to taskpane flow");
-            cancelTimeout();
-            block(event, MAC_NOT_SUPPORTED_MESSAGE);
-            return;
-          }
-
-          try {
-            await encryptAndApply(event, item, to, cc, attachments);
-            cancelTimeout();
-            event.completed({ allowEvent: true });
-          } catch (e) {
-            cancelTimeout();
-            const msg = e instanceof Error ? e.message : String(e);
-            block(event, `Encryption failed: ${msg}`);
-          }
-          return;
-        }
-
-        // Verify the encryption matches the message's current To+Cc list.
-        const currentKey = recipientsKey([...to, ...cc]);
-        const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
-        log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
-
-        cancelTimeout();
-        if (stale) {
-          block(event, STALE_ENCRYPTION_MESSAGE);
-          return;
-        }
-        event.completed({ allowEvent: true });
-      });
+  item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS], (hdrRes) => {
+    log(`internetHeaders.getAsync status=${hdrRes.status}`);
+    if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
+      cancelTimeout();
+      event.completed({ allowEvent: true });
+      return;
     }
-  );
+
+    const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
+    log(`encryptRequested=${encryptRequested}`);
+    if (!encryptRequested) {
+      cancelTimeout();
+      event.completed({ allowEvent: true });
+      return;
+    }
+
+    const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
+
+    item.getAttachmentsAsync(async (attRes) => {
+      log(`getAttachmentsAsync status=${attRes.status}`);
+      const attachments = attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
+      const alreadyEncrypted = attachments.some(
+        (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+      );
+      log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
+
+      const [to, cc] = await Promise.all([
+        getRecipientsAsync(item.to),
+        getRecipientsAsync(item.cc),
+      ]);
+
+      if (!alreadyEncrypted) {
+        if (to.length + cc.length === 0) {
+          cancelTimeout();
+          block(event, "Add at least one recipient before sending.");
+          return;
+        }
+
+        // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+        // from the launchevent runtime with E_FAIL regardless of options
+        // or sizing. Tracked upstream at office-js#6677; related stale
+        // reports are #3138, #3085, and #5681. Until Microsoft restores
+        // working dialog support, deflect Mac users to the manual
+        // taskpane "Encrypt & Send" button (which uses the dialog API
+        // from the taskpane runtime, where it works). Note: this only
+        // fires when the message is *not* already encrypted — once the
+        // user has clicked Encrypt & Send in the taskpane and we see
+        // the postguard.encrypted attachment, we fall through to the
+        // standard allow-send path. Remove this branch when 6677 ships.
+        if (Office.context.platform === Office.PlatformType.Mac) {
+          log("Outlook for Mac detected; deferring to taskpane flow");
+          cancelTimeout();
+          block(event, MAC_NOT_SUPPORTED_MESSAGE);
+          return;
+        }
+
+        try {
+          await encryptAndApply(event, item, to, cc, attachments);
+          cancelTimeout();
+          event.completed({ allowEvent: true });
+        } catch (e) {
+          cancelTimeout();
+          const msg = e instanceof Error ? e.message : String(e);
+          block(event, `Encryption failed: ${msg}`);
+        }
+        return;
+      }
+
+      // Verify the encryption matches the message's current To+Cc list.
+      const currentKey = recipientsKey([...to, ...cc]);
+      const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
+      log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+
+      cancelTimeout();
+      if (stale) {
+        block(event, STALE_ENCRYPTION_MESSAGE);
+        return;
+      }
+      event.completed({ allowEvent: true });
+    });
+  });
 }
 
 log("script loaded");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,8 +11,6 @@
 // To enable: register an Azure AD app, add Mail.ReadWrite + User.Read scopes,
 // add the <WebApplicationInfo> block to manifest.xml and (re)deploy.
 
-/* global OfficeRuntime */
-
 let cached: { token: string; expiresAt: number } | null = null;
 
 export async function getGraphToken(allowPrompt = false): Promise<string | null> {

--- a/src/lib/mime.ts
+++ b/src/lib/mime.ts
@@ -116,9 +116,7 @@ function collectParts(raw: string, out: ParsedMessage): void {
   const cd = part.headers["content-disposition"] ?? "";
   const cte = (part.headers["content-transfer-encoding"] ?? "7bit").toLowerCase();
   const filename = paramFromHeader(cd, "filename") ?? paramFromHeader(ct, "name");
-  const isAttachment =
-    /attachment/i.test(cd) ||
-    (filename != null && !ctMain.startsWith("text/"));
+  const isAttachment = /attachment/i.test(cd) || (filename != null && !ctMain.startsWith("text/"));
 
   if (isAttachment) {
     out.attachments.push({

--- a/src/lib/office-helpers.ts
+++ b/src/lib/office-helpers.ts
@@ -1,11 +1,7 @@
 // Promisified wrappers around the callback-based Office.js mailbox APIs.
 // All helpers reject if Office.js returns a non-succeeded AsyncResult.
 
-/* global Office */
-
-function p<T>(
-  fn: (cb: (r: Office.AsyncResult<T>) => void) => void
-): Promise<T> {
+function p<T>(fn: (cb: (r: Office.AsyncResult<T>) => void) => void): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     fn((res) => {
       if (res.status === Office.AsyncResultStatus.Succeeded) {
@@ -62,9 +58,7 @@ export function getBody(format: Office.CoercionType = Office.CoercionType.Html):
 
 export function setBody(html: string): Promise<void> {
   const item = getItem() as Office.MessageCompose;
-  return p<void>((cb) =>
-    item.body.setAsync(html, { coercionType: Office.CoercionType.Html }, cb)
-  );
+  return p<void>((cb) => item.body.setAsync(html, { coercionType: Office.CoercionType.Html }, cb));
 }
 
 export function getAttachmentsCompose(): Promise<Office.AttachmentDetailsCompose[]> {
@@ -72,11 +66,11 @@ export function getAttachmentsCompose(): Promise<Office.AttachmentDetailsCompose
   return p<Office.AttachmentDetailsCompose[]>((cb) => item.getAttachmentsAsync(cb));
 }
 
-export function getAttachmentContentCompose(attachmentId: string): Promise<Office.AttachmentContent> {
+export function getAttachmentContentCompose(
+  attachmentId: string
+): Promise<Office.AttachmentContent> {
   const item = getItem() as Office.MessageCompose;
-  return p<Office.AttachmentContent>((cb) =>
-    item.getAttachmentContentAsync(attachmentId, cb)
-  );
+  return p<Office.AttachmentContent>((cb) => item.getAttachmentContentAsync(attachmentId, cb));
 }
 
 export function removeAttachment(attachmentId: string): Promise<void> {
@@ -87,9 +81,7 @@ export function removeAttachment(attachmentId: string): Promise<void> {
 // Adds a base64 inline file attachment. Returns the attachment id assigned by Outlook.
 export function addBase64Attachment(filename: string, base64: string): Promise<string> {
   const item = getItem() as Office.MessageCompose;
-  return p<string>((cb) =>
-    item.addFileAttachmentFromBase64Async(base64, filename, cb as never)
-  );
+  return p<string>((cb) => item.addFileAttachmentFromBase64Async(base64, filename, cb as never));
 }
 
 // Commits the current draft (subject, body, attachments) to the server. We need
@@ -130,7 +122,9 @@ export function getReadAttachments(): Office.AttachmentDetails[] {
   return item.attachments ?? [];
 }
 
-export function getReadBody(format: Office.CoercionType = Office.CoercionType.Html): Promise<string> {
+export function getReadBody(
+  format: Office.CoercionType = Office.CoercionType.Html
+): Promise<string> {
   const item = getItem() as Office.MessageRead;
   return p<string>((cb) => item.body.getAsync(format, cb));
 }
@@ -177,9 +171,7 @@ function parseInternetHeaders(raw: string, names: string[]): Record<string, stri
 }
 
 // Reads attachment bytes (compose mode). Returns ArrayBuffer.
-export async function readComposeAttachmentBytes(
-  attachmentId: string
-): Promise<ArrayBuffer> {
+export async function readComposeAttachmentBytes(attachmentId: string): Promise<ArrayBuffer> {
   const content = await getAttachmentContentCompose(attachmentId);
   if (content.format === Office.MailboxEnums.AttachmentContentFormat.Base64) {
     return base64ToArrayBuffer(content.content);
@@ -201,8 +193,14 @@ export function getReadAttachmentContent(attachmentId: string): Promise<Office.A
   const item = getItem() as Office.MessageRead;
   // getAttachmentContentAsync also exists in read mode.
   return p<Office.AttachmentContent>((cb) =>
-    (item as unknown as { getAttachmentContentAsync: (id: string, cb: (r: Office.AsyncResult<Office.AttachmentContent>) => void) => void })
-      .getAttachmentContentAsync(attachmentId, cb)
+    (
+      item as unknown as {
+        getAttachmentContentAsync: (
+          id: string,
+          cb: (r: Office.AsyncResult<Office.AttachmentContent>) => void
+        ) => void;
+      }
+    ).getAttachmentContentAsync(attachmentId, cb)
   );
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,8 +1,6 @@
 // Persistent per-mailbox storage using Office roamingSettings.
 // roamingSettings is JSON-serializable, ~32KB total budget.
 
-/* global Office */
-
 export function getSetting<T>(key: string, fallback: T): T {
   const v = Office.context.roamingSettings.get(key) as T | undefined;
   return v === undefined || v === null ? fallback : v;

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -21,17 +21,8 @@ import {
 } from "../lib/office-helpers";
 import { toBase64 } from "../lib/encoding";
 import { EMAIL_ATTRIBUTE_TYPE } from "../lib/attributes";
-import {
-  Policy,
-  AttributeRequest,
-  MimeAttachment,
-} from "../lib/types";
-import {
-  PKG_URL,
-  CRYPTIFY_URL,
-  POSTGUARD_WEBSITE_URL,
-  clientHeaders,
-} from "../lib/pkg-client";
+import { Policy, AttributeRequest, MimeAttachment } from "../lib/types";
+import { PKG_URL, CRYPTIFY_URL, POSTGUARD_WEBSITE_URL, clientHeaders } from "../lib/pkg-client";
 import { POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
 import { t } from "../lib/i18n";
 import { mountPolicyPanel } from "./policy-editor";
@@ -67,10 +58,9 @@ async function persistEncryptOnSend(value: boolean): Promise<void> {
     await saveItem();
     await setItemHeaders({ [HEADER_ENCRYPT_ON_SEND]: value ? "true" : "false" });
     await saveItem();
-    // eslint-disable-next-line no-console
+
     console.log(`[pg] persisted encryptOnSend=${value}`);
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error(`[pg] failed to persist encryptOnSend:`, e);
   }
 }
@@ -165,8 +155,7 @@ export async function mountComposeView(): Promise<void> {
   // (office-js#6677). Every other client opens the dialog directly
   // when the user hits Outlook's native Send, so the button is just
   // confusing UX there. Hide unless platform is Mac.
-  btnEncryptSend.hidden =
-    Office.context.platform !== Office.PlatformType.Mac;
+  btnEncryptSend.hidden = Office.context.platform !== Office.PlatformType.Mac;
 
   toggle.addEventListener("change", () => {
     state.encrypt = toggle.checked;
@@ -278,10 +267,7 @@ function renderPolicyPanels(): void {
   // Sign editor is conceptually a single-recipient policy where the
   // "recipient" is the sender's own address.
   const signInitial: Policy = {
-    [senderEmail]: [
-      { t: EMAIL_ATTRIBUTE_TYPE, v: senderEmail },
-      ...state.signAttributes,
-    ],
+    [senderEmail]: [{ t: EMAIL_ATTRIBUTE_TYPE, v: senderEmail }, ...state.signAttributes],
   };
   mountPolicyPanel(signContainer, {
     emails: [senderEmail],
@@ -290,9 +276,7 @@ function renderPolicyPanels(): void {
       // signAttributes stores ONLY extras. pg.sign.yivi already takes
       // senderEmail as a top-level field; including email here as well
       // triggers a second email disclosure on the Yivi QR.
-      state.signAttributes = (next[senderEmail] ?? []).filter(
-        (a) => a.t !== EMAIL_ATTRIBUTE_TYPE
-      );
+      state.signAttributes = (next[senderEmail] ?? []).filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE);
     },
   });
 }
@@ -308,24 +292,17 @@ function renderToggleUI(): void {
     ? t("composeSwitchBarEnabled")
     : t("composeSwitchBarDisabled");
 
-  const hasRecipients =
-    state.recipients.to.length + state.recipients.cc.length > 0;
+  const hasRecipients = state.recipients.to.length + state.recipients.cc.length > 0;
   const bccPresent = state.recipients.bcc.length > 0;
 
   // Re-encrypt mode: after a successful encryption, the button is only
   // useful if recipients/policy/sign attributes have drifted from what's
   // already on the draft. Otherwise re-clicking would just rebuild the
   // exact same envelope.
-  const needsReencrypt =
-    state.encrypted && relevantStateString() !== state.encryptedSnapshot;
-  btnEncryptSend.textContent = state.encrypted
-    ? t("reencryptAndSend")
-    : t("encryptAndSend");
+  const needsReencrypt = state.encrypted && relevantStateString() !== state.encryptedSnapshot;
+  btnEncryptSend.textContent = state.encrypted ? t("reencryptAndSend") : t("encryptAndSend");
   btnEncryptSend.disabled =
-    !state.encrypt ||
-    !hasRecipients ||
-    bccPresent ||
-    (state.encrypted && !needsReencrypt);
+    !state.encrypt || !hasRecipients || bccPresent || (state.encrypted && !needsReencrypt);
 
   // Sync the x-pg-encrypted-recipients header to the current state. It
   // should hold the recipient list when the encryption is current, and be
@@ -416,7 +393,7 @@ async function encryptAndPrepareSend(): Promise<void> {
     const html = await getBody(Office.CoercionType.Html);
     const attachments = await collectComposeAttachments();
 
-    const mime = await buildMime({
+    const mime = (await buildMime({
       from: senderEmail,
       to: state.recipients.to,
       cc: state.recipients.cc,
@@ -428,7 +405,7 @@ async function encryptAndPrepareSend(): Promise<void> {
         type: a.type,
         data: a.data,
       })),
-    } as never) as Uint8Array;
+    } as never)) as Uint8Array;
 
     showView("yivi");
     const yiviTitle = byId<HTMLElement>("pg-yivi-title");
@@ -535,8 +512,9 @@ async function encryptAndPrepareSend(): Promise<void> {
 function buildPgRecipients(pg: PostGuard): unknown[] {
   const all = [...state.recipients.to, ...state.recipients.cc];
   return all.map((email) => {
-    const builder = (pg as never as { recipient: { email: (e: string) => RecipientBuilder } })
-      .recipient.email(email);
+    const builder = (
+      pg as never as { recipient: { email: (e: string) => RecipientBuilder } }
+    ).recipient.email(email);
     const policy = state.policy[email];
     if (policy) {
       for (const attr of policy) {
@@ -553,9 +531,7 @@ interface RecipientBuilder {
   extraAttribute(t: string, v: string): RecipientBuilder;
 }
 
-async function collectComposeAttachments(): Promise<
-  (MimeAttachment & { id: string })[]
-> {
+async function collectComposeAttachments(): Promise<(MimeAttachment & { id: string })[]> {
   const list = await getAttachmentsCompose();
   const out: (MimeAttachment & { id: string })[] = [];
   for (const a of list) {

--- a/src/taskpane/policy-editor.ts
+++ b/src/taskpane/policy-editor.ts
@@ -8,11 +8,7 @@
 // a × delete button, and unselected attributes are shown as "+" chips that
 // add a fresh row when clicked.
 
-import {
-  AttributeDescriptor,
-  EMAIL_ATTRIBUTE_TYPE,
-  SUPPORTED_ATTRIBUTES,
-} from "../lib/attributes";
+import { AttributeDescriptor, EMAIL_ATTRIBUTE_TYPE, SUPPORTED_ATTRIBUTES } from "../lib/attributes";
 import { Policy, AttributeRequest } from "../lib/types";
 import { t } from "../lib/i18n";
 
@@ -22,10 +18,7 @@ interface PolicyPanelOptions {
   onChange: (next: Policy) => void;
 }
 
-export function mountPolicyPanel(
-  container: HTMLElement,
-  opts: PolicyPanelOptions
-): void {
+export function mountPolicyPanel(container: HTMLElement, opts: PolicyPanelOptions): void {
   // Working state for this panel — extras only (email is implicit).
   const working = new Map<string, AttributeRequest[]>();
   for (const email of opts.emails) {
@@ -39,9 +32,7 @@ export function mountPolicyPanel(
   const fireChange = () => {
     const result: Policy = {};
     for (const [email, extras] of working.entries()) {
-      const valid = extras
-        .map((a) => ({ t: a.t, v: a.v.trim() }))
-        .filter((a) => a.v.length > 0);
+      const valid = extras.map((a) => ({ t: a.t, v: a.v.trim() })).filter((a) => a.v.length > 0);
       result[email] = [{ t: EMAIL_ATTRIBUTE_TYPE, v: email }, ...valid];
     }
     opts.onChange(result);
@@ -88,10 +79,16 @@ function rerenderRecipient(
     const desc = SUPPORTED_ATTRIBUTES.find((d) => d.type === extras[i].t);
     if (!desc) continue;
     section.appendChild(
-      renderAttrRow(extras, i, desc, () => {
-        rerenderRecipient(working, section, email, fireChange);
-        fireChange();
-      }, fireChange)
+      renderAttrRow(
+        extras,
+        i,
+        desc,
+        () => {
+          rerenderRecipient(working, section, email, fireChange);
+          fireChange();
+        },
+        fireChange
+      )
     );
   }
 

--- a/src/taskpane/read-view.ts
+++ b/src/taskpane/read-view.ts
@@ -19,7 +19,6 @@ import {
 import { fromBase64, bytesToUtf8 } from "../lib/encoding";
 import {
   POSTGUARD_ENCRYPTED_FILENAME,
-  POSTGUARD_HEADER,
   extractArmoredCiphertext,
   looksLikePostGuard,
   parseDecryptedMime,
@@ -52,11 +51,10 @@ export async function mountReadView(): Promise<void> {
   if (ciphertext) {
     state.ciphertext = ciphertext;
     showEncryptedView();
-    await showNotification(
-      "postguard-encrypted-banner",
-      t("displayScriptDecryptBar"),
-      { type: "informational", persistent: true }
-    );
+    await showNotification("postguard-encrypted-banner", t("displayScriptDecryptBar"), {
+      type: "informational",
+      persistent: true,
+    });
     return;
   }
 
@@ -92,9 +90,7 @@ function showEncryptedView(): void {
 async function tryFindCiphertext(): Promise<Uint8Array | null> {
   // Path 1: postguard.encrypted attachment.
   const attachments = getReadAttachments();
-  const enc = attachments.find(
-    (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
-  );
+  const enc = attachments.find((a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME);
   if (enc) {
     try {
       const buf = await readReadAttachmentBytes(enc.id);
@@ -173,9 +169,11 @@ async function runDecryption(): Promise<void> {
       headers: clientHeaders(ADDIN_VERSION),
     } as never);
 
-    const opened = (pg as never as {
-      open: (input: { data: Uint8Array }) => OpenedMessage;
-    }).open({ data: state.ciphertext });
+    const opened = (
+      pg as never as {
+        open: (input: { data: Uint8Array }) => OpenedMessage;
+      }
+    ).open({ data: state.ciphertext });
 
     const result = await opened.decrypt({
       element: "#yivi-web-form",
@@ -234,8 +232,7 @@ function renderDecrypted(plaintext: Uint8Array, sender: FriendlySender | null): 
   }
 
   const parsed = parseDecryptedMime(mime);
-  const bodyText =
-    parsed.htmlBody ?? parsed.plainBody ?? "";
+  const bodyText = parsed.htmlBody ?? parsed.plainBody ?? "";
   const isHtml = parsed.htmlBody != null;
 
   const iframe = byId<HTMLIFrameElement>("pg-decrypted-body");

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -5,8 +5,6 @@ import { isComposeMode } from "../lib/office-helpers";
 import { mountComposeView } from "./compose-view";
 import { mountReadView } from "./read-view";
 
-/* global Office */
-
 const views = {
   loading: byId("view-loading"),
   compose: byId("view-compose"),
@@ -67,7 +65,7 @@ async function bootstrap(): Promise<void> {
   try {
     const compose = isComposeMode();
     const subjType = typeof (Office.context.mailbox.item as { subject?: unknown })?.subject;
-    // eslint-disable-next-line no-console
+
     console.log(
       `[pg-taskpane] bootstrap platform=${Office.context.platform} ` +
         `host=${Office.context.host} compose=${compose} subjectType=${subjType}`
@@ -79,7 +77,7 @@ async function bootstrap(): Promise<void> {
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "PostGuard failed to start.";
-    // eslint-disable-next-line no-console
+
     console.error(`[pg-taskpane] bootstrap threw: ${message}`, err);
     showError(message);
   }

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -11,14 +11,7 @@
 import { PostGuard, buildMime } from "@e4a/pg-js";
 import { toBase64, fromBase64 } from "../lib/encoding";
 import { PKG_URL, CRYPTIFY_URL, POSTGUARD_WEBSITE_URL } from "../lib/pkg-client";
-import {
-  ChunkAssembler,
-  chunkPayload,
-  isChunkMessage,
-  ChunkMessage,
-} from "../lib/dialog-chunk";
-
-/* global Office */
+import { ChunkAssembler, chunkPayload, isChunkMessage, ChunkMessage } from "../lib/dialog-chunk";
 
 const ADDIN_VERSION = "0.1.0";
 
@@ -57,7 +50,6 @@ interface DialogMessage {
 const inboundChunks = new ChunkAssembler();
 
 function log(msg: string): void {
-  // eslint-disable-next-line no-console
   console.log(`[pg-dialog] ${msg}`);
 }
 
@@ -166,7 +158,9 @@ async function runEncryption(req: EncryptRequest): Promise<EncryptResult> {
     const attBytes = new Uint8Array(await envelope.attachment.arrayBuffer());
     attBase64 = toBase64(attBytes);
   }
-  log(`tier=${envelope.tier} uploadUuid=${envelope.uploadUuid ?? "null"} attLen=${attBase64?.length ?? 0}`);
+  log(
+    `tier=${envelope.tier} uploadUuid=${envelope.uploadUuid ?? "null"} attLen=${attBase64?.length ?? 0}`
+  );
 
   return {
     type: "encrypt-result",
@@ -213,8 +207,7 @@ Office.onReady(() => {
   // after AppleWebKit; WKWebView omits the Safari token. Chromium
   // browsers spoof AppleWebKit but include "Chrome" or "Edg".
   const ua = navigator.userAgent || "";
-  const isSafari =
-    /AppleWebKit/.test(ua) && /Safari\//.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
+  const isSafari = /AppleWebKit/.test(ua) && /Safari\//.test(ua) && !/Chrome|Edg|OPR\//.test(ua);
   if (isSafari) {
     const tip = document.getElementById("pg-dlg-safari-tip");
     if (tip) tip.hidden = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "esnext",
     "noEmitOnError": true,
     "outDir": "lib",
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "es2020",


### PR DESCRIPTION
## Summary
- **TypeScript 6:** Bump `typescript` from `^5.9.3` to `^6.0.3`. Drop the deprecated `baseUrl` (no `paths` mapping was set, so it was a no-op). Switch `moduleResolution` from `node` (now aliased `node10`, deprecated in TS 6) to `bundler`, the right fit for our webpack + `module: "esnext"` setup. Add `skipLibCheck: true` (recommended for app projects; bundler resolution surfaces an `fdir → picomatch` declaration issue in transitive build tooling).
- **ESLint:** Replace the inert legacy `.eslintrc.json` (ignored under ESLint 9) with a flat-config `eslint.config.mjs` that inherits `eslint-plugin-office-addins`'s recommended config and supplies the browser + Office globals the rules were missing. Disable `no-undef` for TS files (TypeScript itself covers this and ESLint can't see ambient DOM types like `RequestInit` / `BlobPart`); configure `no-unused-vars` to honour the `_`-prefix convention.
- **Lint fixes:** Auto-fix prettier formatting; drop now-redundant `/* global Office */` comment headers; remove unused `NOT_ENCRYPTED_MESSAGE` and `POSTGUARD_HEADER`; drop dead `eslint-disable` directives. Result: `npm run lint` is clean (256 → 0).
- **CI:** Add `.github/workflows/ci.yml` running lint (`--max-warnings=0`), `tsc --noEmit`, webpack build, and manifest validate on every PR and master push.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint -c eslint.config.mjs --max-warnings=0 "src/**/*.{ts,js}"` — clean
- [x] `npm run build` — succeeds (only pre-existing webpack asset-size warnings)
- [x] `npm run validate` — manifest valid
- [ ] Sideload and smoke-test compose + read flows in new Outlook on Windows
- [ ] Sideload and smoke-test compose + read flows in Outlook for Mac