### PR TITLE
chore(deps): bump @e4a/pg-js to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-js": "^1.3.0",
+        "@e4a/pg-js": "^1.5.0",
         "core-js": "^3.49.0",
         "regenerator-runtime": "^0.14.1"
       },
@@ -2506,16 +2506,16 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.3.0.tgz",
-      "integrity": "sha512-0e31LLos0XmXlYZ/TqJb6j1RStzICEmyC8s9qjVgF1w3z4hnnevRq2c0/9XpsZseFi0Vwr6S7GqZoKtqvcd8HQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
+      "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-wasm": "^0.5.9",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.4",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.4",
+        "@e4a/pg-wasm": "^0.5.10",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
         "@transcend-io/conflux": "^6.1.3"
       }
     },
@@ -7108,40 +7108,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.4.tgz",
-      "integrity": "sha512-1B0NryDau4rkv6w6Y2eLesoynuVvKNEKC/6MZPdPMDo8ecnN02bZM+gpogqO0Th94NKK+iXtRREqKWaopXJhIQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
+      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-xkwTLfVRnGW7RTLjPMvLYbnvYz/ULpZZnzKJwXP9zNdHup0Ol2JGN83dIvq979CtG2vdJUeh8hOoQfPsFaiqnQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.4.tgz",
-      "integrity": "sha512-ccV8Wb39gChj9t6nYugYrd5QVvsC9AmQhonsEkBVUX3JQavZVeowTX4Y+VBonJVDfPAvPLaqUdlnVhIDnRLPvA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
+      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.4.tgz",
-      "integrity": "sha512-+TMKX1NlHHAD3Lk8MFDcATzDK4muc/1zmyKD3Nwfk8WRb4p2RNNeqwCvztVmZ6V8OVGFFJOT2gMPRv/Z/e2egA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
+      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.4"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@e4a/pg-js": "^1.3.0",
+    "@e4a/pg-js": "^1.5.0",
     "core-js": "^3.49.0",
     "regenerator-runtime": "^0.14.1"
   },


### PR DESCRIPTION
Picks up [encryption4all/postguard-js#52](https://github.com/encryption4all/postguard-js/pull/52) (resumable downloads via Range on transient failures) and [#47](https://github.com/encryption4all/postguard-js/pull/47) (chunk PUT retry/backoff, \`UploadSessionExpiredError\`).

## Public-API note

pg-js's \`downloadFileWithRetry\` now returns the \`ReadableStream\` **synchronously** instead of via a Promise. The addon does not call that function directly — it consumes pg-js via \`PostGuard.open()\` / \`Opened.decrypt()\`, which is unchanged. No addon-side code change needed at the SDK boundary in \`compose-view.ts\` / \`read-view.ts\`.

## Test plan

- [x] \`npm install\` — resolves to 1.5.0
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean (the two entrypoint-size warnings are pre-existing, unrelated to pg-js)
- [ ] Manual: load the addon in Outlook (sideload via \`npm start\`), compose+send and read+decrypt against dev cryptify

## WASM-loader workaround note

The pg-js bump may obviate the \`parser: { url: false }\` rule in \`webpack.config.js\` that worked around the dead \`new URL(\"index_bg.wasm\", ...)\` branch in the wasm-bindgen shim. Tracked upstream at encryption4all/postguard-js#30 (closed). Not removing the rule in this PR — narrow change, easier to revert. Worth a follow-up to confirm the workaround is no longer needed against 1.5.0.