### PR TITLE
chore: bump @e4a/pg-js to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-js": "^1.5.0",
+        "@e4a/pg-js": "^1.6.0",
         "core-js": "^3.49.0",
         "regenerator-runtime": "^0.14.1"
       },
@@ -2506,16 +2506,16 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
-      "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.6.0.tgz",
+      "integrity": "sha512-O9KR82k1jjOJHy7WHUcV9ZzhR84t3FTISIXyB9ir9ivkCj51+Y1YjwH35NjEMurefVO4fYFOFgiiejn6ykl79A==",
       "license": "MIT",
       "dependencies": {
         "@e4a/pg-wasm": "^0.5.10",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.6",
         "@transcend-io/conflux": "^6.1.3"
       }
     },
@@ -7108,40 +7108,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
-      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.6.tgz",
+      "integrity": "sha512-oiplBNmU7cZkxQkynB9Sf4U363Cn4XXoF9NnvWO2qeLoCudpxI7e96zcZW91GASPxFyW7vjJKTNUepkX6N01nA==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
-      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.6.tgz",
+      "integrity": "sha512-uHdiV+xlYYLvK49nPpvOYXR1xBJX7WDY7jSVGVLdLRW4qlY4D2UCGgESejxOTY825Mp5TVs4O2E7qrMnvIWLUQ==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
-      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.6.tgz",
+      "integrity": "sha512-dBewDFIMRsf6tOs8RvkCUQPOgNASazApK1HCvAXmkPvTUaMfBONvgBOuUZ/QPKawsTxiCOmMgCm7+746YsgL+Q==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
-      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.6.tgz",
+      "integrity": "sha512-rYD45/YLDD0sfKsIPISDaPU8nCGnax7Q195fyQtP3XpyfD6S5Z5ciRXN5kydHg2izg7Ld4+V9IpgjwMCtAst/g==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@e4a/pg-js": "^1.5.0",
+    "@e4a/pg-js": "^1.6.0",
     "core-js": "^3.49.0",
     "regenerator-runtime": "^0.14.1"
   },


### PR DESCRIPTION
## Summary
- Bumps `@e4a/pg-js` from `^1.5.0` to `^1.6.0`.

pg-js 1.6.0 ships the new `@privacybydesign/yivi-*` 1.0.0-beta.6, which renders the QR as SVG for crisp resizing at any size.

## Test plan
- [ ] `npm install` succeeds
- [ ] Build and tests pass
- [ ] QR code displays sharp at all sizes