### PR TITLE
fix(launchevent): prompt before opening Yivi dialog by default (#48)

### DIFF
--- a/docs/outlook-quirks.md
+++ b/docs/outlook-quirks.md
@@ -338,6 +338,29 @@ element found") to the console. The parse failure is internal to OWA's probe
 logic — the actual taskpane mount uses the response normally and your `Office.onReady`
 code runs fine after this error. Safe to ignore.
 
+### `displayDialogAsync` defaults to `promptBeforeOpen: true` (#48)
+
+The `OnMessageSend` launchevent opens the Yivi dialog via
+`Office.context.ui.displayDialogAsync`. The `promptBeforeOpen` option governs
+whether Office shows its "PostGuard wants to open a dialog → Allow"
+confirmation before the popup. Default in this add-in is `true`, because:
+
+- The Allow click is itself a fresh user gesture, so the popup opens reliably
+  on every host — including Safari without site-level popup permission.
+- The previous "optimistic" path (`promptBeforeOpen: false` first, retry with
+  the prompt on failure) tripped Safari's popup blocker before any retry could
+  attach a real gesture, surfacing a confusing security error to the user.
+
+Power users who have already granted permanent popup permission to the add-in's
+origin can flip *Skip the "open a dialog" confirmation* in the taskpane's
+Settings view (roaming-setting key `pg.allowOptimisticDialog`). That switches
+to `promptBeforeOpen: false`; on the rare host where it's still blocked we
+recover with a single prompted retry so the send isn't lost.
+
+`runEncryptDialog` in `src/launchevent/launchevent.ts` reads the setting via
+`getAllowOptimisticDialog()`; `roamingSettings` is available in the launchevent
+runtime so no extra plumbing is required.
+
 ---
 
 ## Things we still don't fully understand

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@e4a/pg-js": "^1.5.0",
+        "@e4a/pg-js": "^1.6.0",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.7",
         "core-js": "^3.49.0",
         "regenerator-runtime": "^0.14.1"
       },
@@ -2506,16 +2507,16 @@
       }
     },
     "node_modules/@e4a/pg-js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.5.0.tgz",
-      "integrity": "sha512-yade4VriSbfyyn2+ydK+IaB5KOr24ZQiL7GUDnO3cZEq9XOMY+WhLERBkLcUFBRw8Pi07UxYnr0fti93beP1Cw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@e4a/pg-js/-/pg-js-1.6.0.tgz",
+      "integrity": "sha512-O9KR82k1jjOJHy7WHUcV9ZzhR84t3FTISIXyB9ir9ivkCj51+Y1YjwH35NjEMurefVO4fYFOFgiiejn6ykl79A==",
       "license": "MIT",
       "dependencies": {
         "@e4a/pg-wasm": "^0.5.10",
-        "@privacybydesign/yivi-client": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-css": "^1.0.0-beta.5",
-        "@privacybydesign/yivi-web": "^1.0.0-beta.5",
+        "@privacybydesign/yivi-client": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-css": "^1.0.0-beta.6",
+        "@privacybydesign/yivi-web": "^1.0.0-beta.6",
         "@transcend-io/conflux": "^6.1.3"
       }
     },
@@ -7108,40 +7109,40 @@
       }
     },
     "node_modules/@privacybydesign/yivi-client": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.5.tgz",
-      "integrity": "sha512-9jwOl2r6UidHDTQfDsJD+H6jWZQrWCEfEyrhAMTYautMsfTVKyNgNNP1x9SR7b7A/8u3n5YAarNpGKqX+eApEg==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-client/-/yivi-client-1.0.0-beta.6.tgz",
+      "integrity": "sha512-oiplBNmU7cZkxQkynB9Sf4U363Cn4XXoF9NnvWO2qeLoCudpxI7e96zcZW91GASPxFyW7vjJKTNUepkX6N01nA==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@privacybydesign/yivi-core": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.5.tgz",
-      "integrity": "sha512-PvLMOLawmjdt5TWUeTYW3b84RGVn8JpdXdWup7omqs6Lp4POw4AAX6+8GksMbR9Zc8NXEiSgqQqyDOB1W2h5HA==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-core/-/yivi-core-1.0.0-beta.6.tgz",
+      "integrity": "sha512-uHdiV+xlYYLvK49nPpvOYXR1xBJX7WDY7jSVGVLdLRW4qlY4D2UCGgESejxOTY825Mp5TVs4O2E7qrMnvIWLUQ==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-css": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.5.tgz",
-      "integrity": "sha512-MsEs7YTEyJshJuhP0mWblRB4bDy0MBxR4ABSMFyNYf2BOXa1SNPcKtxCn4qznG1L2pk1MCI7CRZzBNyCGORg5g==",
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-css/-/yivi-css-1.0.0-beta.7.tgz",
+      "integrity": "sha512-2udKhHfXi3/u1QIJ4oGI6xYt5YEdqSlqERnIKlXrC0kIjhrVsQNumLNj5S5DDYwBm4ODfmWluPZsyxQ56YQYZQ==",
       "license": "SEE LICENSE IN REPOSITORY"
     },
     "node_modules/@privacybydesign/yivi-web": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.5.tgz",
-      "integrity": "sha512-hH3Srygx0GSKsyI7zdZb6fj9cb0A5+qHISiGBLfkzUuASue9lcbdZqqpHV4/jGl15/IcdNwfp/CtlbInow/Clw==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-web/-/yivi-web-1.0.0-beta.6.tgz",
+      "integrity": "sha512-rYD45/YLDD0sfKsIPISDaPU8nCGnax7Q195fyQtP3XpyfD6S5Z5ciRXN5kydHg2izg7Ld4+V9IpgjwMCtAst/g==",
       "license": "SEE LICENSE IN REPOSITORY",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "qrcode": "^1.4.2"
       },
       "peerDependencies": {
-        "@privacybydesign/yivi-core": "^1.0.0-beta.5"
+        "@privacybydesign/yivi-core": "^1.0.0-beta.6"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@e4a/pg-js": "^1.5.0",
+    "@e4a/pg-js": "^1.6.0",
+    "@privacybydesign/yivi-css": "^1.0.0-beta.7",
     "core-js": "^3.49.0",
     "regenerator-runtime": "^0.14.1"
   },

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -18,6 +18,7 @@
 
 import { ChunkAssembler, chunkPayload, isChunkMessage, ChunkMessage } from "../lib/dialog-chunk";
 import { ADDIN_PUBLIC_URL } from "../lib/pkg-client";
+import { getAllowOptimisticDialog } from "../lib/settings";
 import { stringifyError } from "../lib/stringify-error";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
@@ -268,32 +269,33 @@ async function runEncryptDialog(payload: DialogMessage): Promise<EncryptResult> 
     displayInIframe: false,
   };
 
-  // Try to open without Office's "open another window" prompt first.
-  // Browsers that allow popups from the Outlook host (Chrome, Edge,
-  // Firefox by default; Safari once the user has granted popup
-  // permission) get a one-click send. If the optimistic attempt fails
-  // — typically Safari's popup blocker silently denying — retry with
-  // promptBeforeOpen: true so the Office prompt fires and the user's
-  // click on Allow becomes the gesture that releases the popup. The
-  // dialog itself shows a Safari-only inline hint pointing at
-  // Settings → Websites → Pop-ups so the user can opt out of the
-  // recurring prompt by granting permission once.
+  // Default: open with Office's "PostGuard wants to open a dialog"
+  // confirmation. The user's click on Allow is itself a fresh user
+  // gesture, so the popup opens reliably on every host (including
+  // Safari without site-level popup permission). Power users who have
+  // permanently allowed pop-ups for the add-in's origin can flip the
+  // Settings toggle (taskpane → gear → Skip the "open a dialog"
+  // confirmation) to opt into a single-attempt optimistic open. If
+  // that attempt is still blocked we recover by re-trying with the
+  // prompt so the send isn't lost.
+  const allowOptimistic = getAllowOptimisticDialog();
+  log(`displayDialogAsync: promptBeforeOpen=${!allowOptimistic} (optimistic=${allowOptimistic})`);
   let dialog: Office.Dialog;
   try {
-    log("displayDialogAsync attempt 1: promptBeforeOpen=false");
     dialog = await openDialogAsync(YIVI_DIALOG_URL, {
       ...baseOptions,
-      promptBeforeOpen: false,
+      promptBeforeOpen: !allowOptimistic,
     });
-    log("dialog opened (no prompt)");
-  } catch (e1) {
-    const msg1 = (e1 as { message?: string })?.message ?? String(e1);
-    log(`attempt 1 failed (${msg1}); retrying with promptBeforeOpen=true`);
+    log(allowOptimistic ? "dialog opened (no prompt)" : "dialog opened (after prompt)");
+  } catch (e) {
+    if (!allowOptimistic) throw e;
+    const msg = (e as { message?: string })?.message ?? String(e);
+    log(`optimistic attempt failed (${msg}); retrying with promptBeforeOpen=true`);
     dialog = await openDialogAsync(YIVI_DIALOG_URL, {
       ...baseOptions,
       promptBeforeOpen: true,
     });
-    log("dialog opened (after prompt)");
+    log("dialog opened (after prompt fallback)");
   }
 
   return new Promise((resolve, reject) => {

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -451,7 +451,9 @@ async function encryptAndApply(
   // launchevent runtime, so we don't need a per-draft internet header.
   const signAttributes = buildSignAttributes();
   log(
-    `signAttributes=${signAttributes.map((a) => `${a.t}${a.v ? "=set" : ":optional"}`).join(",")}`
+    `signAttributes=${signAttributes
+      .map((a) => `${a.t}${a.v ? `=${a.v}` : a.optional ? ":optional" : ""}`)
+      .join(", ")}`
   );
 
   const result = await runEncryptDialog({

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -18,13 +18,12 @@
 
 import { ChunkAssembler, chunkPayload, isChunkMessage, ChunkMessage } from "../lib/dialog-chunk";
 import { ADDIN_PUBLIC_URL } from "../lib/pkg-client";
-import { getAllowOptimisticDialog } from "../lib/settings";
+import { buildSignAttributes, getAllowOptimisticDialog } from "../lib/settings";
 import { stringifyError } from "../lib/stringify-error";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
 const HEADER_POSTGUARD = "x-postguard";
-const HEADER_SIGN_ATTRIBUTES = "x-pg-sign-attributes";
 const POSTGUARD_VERSION = "0.1.0";
 const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
 const COMPOSE_BUTTON_ID = "postGuardComposeButton";
@@ -440,13 +439,20 @@ async function encryptAndApply(
   item: Office.MessageCompose,
   to: Office.EmailAddressDetails[],
   cc: Office.EmailAddressDetails[],
-  userAttachments: Office.AttachmentDetailsCompose[],
-  signAttributes: { t: string; optional?: boolean }[]
+  userAttachments: Office.AttachmentDetailsCompose[]
 ): Promise<void> {
   const senderEmail = Office.context.mailbox.userProfile.emailAddress.toLowerCase();
   const subject = await getSubjectAsync(item);
   const htmlBody = await getBodyHtmlAsync(item);
   const attachments = await readUserAttachments(item, userAttachments);
+
+  // Sender attributes come from per-mailbox roaming settings (configured
+  // in the taskpane Settings view). Roaming settings are available in the
+  // launchevent runtime, so we don't need a per-draft internet header.
+  const signAttributes = buildSignAttributes();
+  log(
+    `signAttributes=${signAttributes.map((a) => `${a.t}${a.v ? "=set" : ":optional"}`).join(",")}`
+  );
 
   const result = await runEncryptDialog({
     type: "encrypt-request",
@@ -501,110 +507,86 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
     return;
   }
 
-  item.internetHeaders.getAsync(
-    [HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS, HEADER_SIGN_ATTRIBUTES],
-    (hdrRes) => {
-      log(`internetHeaders.getAsync status=${hdrRes.status}`);
-      if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
-        cancelTimeout();
-        event.completed({ allowEvent: true });
-        return;
-      }
-
-      const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
-      log(`encryptRequested=${encryptRequested}`);
-      if (!encryptRequested) {
-        cancelTimeout();
-        event.completed({ allowEvent: true });
-        return;
-      }
-
-      const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
-      const rawSignAttrs = hdrRes.value[HEADER_SIGN_ATTRIBUTES] ?? "";
-      let signAttributes: { t: string; optional?: boolean }[] = [];
-      if (rawSignAttrs) {
-        try {
-          const parsed = JSON.parse(rawSignAttrs) as unknown;
-          if (Array.isArray(parsed)) {
-            signAttributes = parsed
-              .filter(
-                (a): a is { t: string } =>
-                  typeof a === "object" &&
-                  a !== null &&
-                  typeof (a as { t?: unknown }).t === "string"
-              )
-              .map((a) => ({ t: a.t, optional: true }));
-          }
-        } catch (e) {
-          log(`failed to parse ${HEADER_SIGN_ATTRIBUTES}: ${String(e)}`);
-        }
-      }
-      log(`signAttributes count=${signAttributes.length}`);
-
-      item.getAttachmentsAsync(async (attRes) => {
-        log(`getAttachmentsAsync status=${attRes.status}`);
-        const attachments =
-          attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
-        const alreadyEncrypted = attachments.some(
-          (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
-        );
-        log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
-
-        const [to, cc] = await Promise.all([
-          getRecipientsAsync(item.to),
-          getRecipientsAsync(item.cc),
-        ]);
-
-        if (!alreadyEncrypted) {
-          if (to.length + cc.length === 0) {
-            cancelTimeout();
-            block(event, "Add at least one recipient before sending.");
-            return;
-          }
-
-          // Outlook for Mac (native WKWebView) rejects displayDialogAsync
-          // from the launchevent runtime with E_FAIL regardless of options
-          // or sizing. Tracked upstream at office-js#6677; related stale
-          // reports are #3138, #3085, and #5681. Until Microsoft restores
-          // working dialog support, deflect Mac users to the manual
-          // taskpane "Encrypt & Send" button (which uses the dialog API
-          // from the taskpane runtime, where it works). Note: this only
-          // fires when the message is *not* already encrypted — once the
-          // user has clicked Encrypt & Send in the taskpane and we see
-          // the postguard.encrypted attachment, we fall through to the
-          // standard allow-send path. Remove this branch when 6677 ships.
-          if (Office.context.platform === Office.PlatformType.Mac) {
-            log("Outlook for Mac detected; deferring to taskpane flow");
-            cancelTimeout();
-            block(event, MAC_NOT_SUPPORTED_MESSAGE);
-            return;
-          }
-
-          try {
-            await encryptAndApply(event, item, to, cc, attachments, signAttributes);
-            cancelTimeout();
-            event.completed({ allowEvent: true });
-          } catch (e) {
-            cancelTimeout();
-            block(event, `Encryption failed: ${stringifyError(e)}`);
-          }
-          return;
-        }
-
-        // Verify the encryption matches the message's current To+Cc list.
-        const currentKey = recipientsKey([...to, ...cc]);
-        const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
-        log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
-
-        cancelTimeout();
-        if (stale) {
-          block(event, STALE_ENCRYPTION_MESSAGE);
-          return;
-        }
-        event.completed({ allowEvent: true });
-      });
+  item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS], (hdrRes) => {
+    log(`internetHeaders.getAsync status=${hdrRes.status}`);
+    if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
+      cancelTimeout();
+      event.completed({ allowEvent: true });
+      return;
     }
-  );
+
+    const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
+    log(`encryptRequested=${encryptRequested}`);
+    if (!encryptRequested) {
+      cancelTimeout();
+      event.completed({ allowEvent: true });
+      return;
+    }
+
+    const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
+
+    item.getAttachmentsAsync(async (attRes) => {
+      log(`getAttachmentsAsync status=${attRes.status}`);
+      const attachments = attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
+      const alreadyEncrypted = attachments.some(
+        (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+      );
+      log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
+
+      const [to, cc] = await Promise.all([
+        getRecipientsAsync(item.to),
+        getRecipientsAsync(item.cc),
+      ]);
+
+      if (!alreadyEncrypted) {
+        if (to.length + cc.length === 0) {
+          cancelTimeout();
+          block(event, "Add at least one recipient before sending.");
+          return;
+        }
+
+        // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+        // from the launchevent runtime with E_FAIL regardless of options
+        // or sizing. Tracked upstream at office-js#6677; related stale
+        // reports are #3138, #3085, and #5681. Until Microsoft restores
+        // working dialog support, deflect Mac users to the manual
+        // taskpane "Encrypt & Send" button (which uses the dialog API
+        // from the taskpane runtime, where it works). Note: this only
+        // fires when the message is *not* already encrypted — once the
+        // user has clicked Encrypt & Send in the taskpane and we see
+        // the postguard.encrypted attachment, we fall through to the
+        // standard allow-send path. Remove this branch when 6677 ships.
+        if (Office.context.platform === Office.PlatformType.Mac) {
+          log("Outlook for Mac detected; deferring to taskpane flow");
+          cancelTimeout();
+          block(event, MAC_NOT_SUPPORTED_MESSAGE);
+          return;
+        }
+
+        try {
+          await encryptAndApply(event, item, to, cc, attachments);
+          cancelTimeout();
+          event.completed({ allowEvent: true });
+        } catch (e) {
+          cancelTimeout();
+          block(event, `Encryption failed: ${stringifyError(e)}`);
+        }
+        return;
+      }
+
+      // Verify the encryption matches the message's current To+Cc list.
+      const currentKey = recipientsKey([...to, ...cc]);
+      const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
+      log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+
+      cancelTimeout();
+      if (stale) {
+        block(event, STALE_ENCRYPTION_MESSAGE);
+        return;
+      }
+      event.completed({ allowEvent: true });
+    });
+  });
 }
 
 log("script loaded");

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -24,6 +24,7 @@ import { stringifyError } from "../lib/stringify-error";
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
 const HEADER_POSTGUARD = "x-postguard";
+const HEADER_SIGN_ATTRIBUTES = "x-pg-sign-attributes";
 const POSTGUARD_VERSION = "0.1.0";
 const POSTGUARD_ENCRYPTED_FILENAME = "postguard.encrypted";
 const COMPOSE_BUTTON_ID = "postGuardComposeButton";
@@ -439,7 +440,8 @@ async function encryptAndApply(
   item: Office.MessageCompose,
   to: Office.EmailAddressDetails[],
   cc: Office.EmailAddressDetails[],
-  userAttachments: Office.AttachmentDetailsCompose[]
+  userAttachments: Office.AttachmentDetailsCompose[],
+  signAttributes: { t: string; optional?: boolean }[]
 ): Promise<void> {
   const senderEmail = Office.context.mailbox.userProfile.emailAddress.toLowerCase();
   const subject = await getSubjectAsync(item);
@@ -454,6 +456,7 @@ async function encryptAndApply(
     subject,
     htmlBody,
     attachments,
+    signAttributes,
   });
 
   await setSubjectAsync(item, result.subject);
@@ -498,86 +501,110 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
     return;
   }
 
-  item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS], (hdrRes) => {
-    log(`internetHeaders.getAsync status=${hdrRes.status}`);
-    if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
-      cancelTimeout();
-      event.completed({ allowEvent: true });
-      return;
-    }
+  item.internetHeaders.getAsync(
+    [HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS, HEADER_SIGN_ATTRIBUTES],
+    (hdrRes) => {
+      log(`internetHeaders.getAsync status=${hdrRes.status}`);
+      if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
+        cancelTimeout();
+        event.completed({ allowEvent: true });
+        return;
+      }
 
-    const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
-    log(`encryptRequested=${encryptRequested}`);
-    if (!encryptRequested) {
-      cancelTimeout();
-      event.completed({ allowEvent: true });
-      return;
-    }
+      const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
+      log(`encryptRequested=${encryptRequested}`);
+      if (!encryptRequested) {
+        cancelTimeout();
+        event.completed({ allowEvent: true });
+        return;
+      }
 
-    const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
-
-    item.getAttachmentsAsync(async (attRes) => {
-      log(`getAttachmentsAsync status=${attRes.status}`);
-      const attachments = attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
-      const alreadyEncrypted = attachments.some(
-        (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
-      );
-      log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
-
-      const [to, cc] = await Promise.all([
-        getRecipientsAsync(item.to),
-        getRecipientsAsync(item.cc),
-      ]);
-
-      if (!alreadyEncrypted) {
-        if (to.length + cc.length === 0) {
-          cancelTimeout();
-          block(event, "Add at least one recipient before sending.");
-          return;
-        }
-
-        // Outlook for Mac (native WKWebView) rejects displayDialogAsync
-        // from the launchevent runtime with E_FAIL regardless of options
-        // or sizing. Tracked upstream at office-js#6677; related stale
-        // reports are #3138, #3085, and #5681. Until Microsoft restores
-        // working dialog support, deflect Mac users to the manual
-        // taskpane "Encrypt & Send" button (which uses the dialog API
-        // from the taskpane runtime, where it works). Note: this only
-        // fires when the message is *not* already encrypted — once the
-        // user has clicked Encrypt & Send in the taskpane and we see
-        // the postguard.encrypted attachment, we fall through to the
-        // standard allow-send path. Remove this branch when 6677 ships.
-        if (Office.context.platform === Office.PlatformType.Mac) {
-          log("Outlook for Mac detected; deferring to taskpane flow");
-          cancelTimeout();
-          block(event, MAC_NOT_SUPPORTED_MESSAGE);
-          return;
-        }
-
+      const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
+      const rawSignAttrs = hdrRes.value[HEADER_SIGN_ATTRIBUTES] ?? "";
+      let signAttributes: { t: string; optional?: boolean }[] = [];
+      if (rawSignAttrs) {
         try {
-          await encryptAndApply(event, item, to, cc, attachments);
-          cancelTimeout();
-          event.completed({ allowEvent: true });
+          const parsed = JSON.parse(rawSignAttrs) as unknown;
+          if (Array.isArray(parsed)) {
+            signAttributes = parsed
+              .filter(
+                (a): a is { t: string } =>
+                  typeof a === "object" &&
+                  a !== null &&
+                  typeof (a as { t?: unknown }).t === "string"
+              )
+              .map((a) => ({ t: a.t, optional: true }));
+          }
         } catch (e) {
-          cancelTimeout();
-          block(event, `Encryption failed: ${stringifyError(e)}`);
+          log(`failed to parse ${HEADER_SIGN_ATTRIBUTES}: ${String(e)}`);
         }
-        return;
       }
+      log(`signAttributes count=${signAttributes.length}`);
 
-      // Verify the encryption matches the message's current To+Cc list.
-      const currentKey = recipientsKey([...to, ...cc]);
-      const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
-      log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+      item.getAttachmentsAsync(async (attRes) => {
+        log(`getAttachmentsAsync status=${attRes.status}`);
+        const attachments =
+          attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
+        const alreadyEncrypted = attachments.some(
+          (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+        );
+        log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
 
-      cancelTimeout();
-      if (stale) {
-        block(event, STALE_ENCRYPTION_MESSAGE);
-        return;
-      }
-      event.completed({ allowEvent: true });
-    });
-  });
+        const [to, cc] = await Promise.all([
+          getRecipientsAsync(item.to),
+          getRecipientsAsync(item.cc),
+        ]);
+
+        if (!alreadyEncrypted) {
+          if (to.length + cc.length === 0) {
+            cancelTimeout();
+            block(event, "Add at least one recipient before sending.");
+            return;
+          }
+
+          // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+          // from the launchevent runtime with E_FAIL regardless of options
+          // or sizing. Tracked upstream at office-js#6677; related stale
+          // reports are #3138, #3085, and #5681. Until Microsoft restores
+          // working dialog support, deflect Mac users to the manual
+          // taskpane "Encrypt & Send" button (which uses the dialog API
+          // from the taskpane runtime, where it works). Note: this only
+          // fires when the message is *not* already encrypted — once the
+          // user has clicked Encrypt & Send in the taskpane and we see
+          // the postguard.encrypted attachment, we fall through to the
+          // standard allow-send path. Remove this branch when 6677 ships.
+          if (Office.context.platform === Office.PlatformType.Mac) {
+            log("Outlook for Mac detected; deferring to taskpane flow");
+            cancelTimeout();
+            block(event, MAC_NOT_SUPPORTED_MESSAGE);
+            return;
+          }
+
+          try {
+            await encryptAndApply(event, item, to, cc, attachments, signAttributes);
+            cancelTimeout();
+            event.completed({ allowEvent: true });
+          } catch (e) {
+            cancelTimeout();
+            block(event, `Encryption failed: ${stringifyError(e)}`);
+          }
+          return;
+        }
+
+        // Verify the encryption matches the message's current To+Cc list.
+        const currentKey = recipientsKey([...to, ...cc]);
+        const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
+        log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+
+        cancelTimeout();
+        if (stale) {
+          block(event, STALE_ENCRYPTION_MESSAGE);
+          return;
+        }
+        event.completed({ allowEvent: true });
+      });
+    }
+  );
 }
 
 log("script loaded");

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -211,13 +211,14 @@ function saveItemAsync(item: Office.MessageCompose): Promise<void> {
   });
 }
 
-// Target physical size of the Yivi dialog. Just large enough for the
-// QR widget (~250×280) plus title and Cancel button. We compute a
-// screen-percentage from these at runtime because Office.displayDialog
-// only accepts percentages — picking fixed percentages gives a tiny
-// dialog on ultrawide monitors and an oversized one on laptops.
-const YIVI_DIALOG_TARGET_WIDTH_PX = 300;
-const YIVI_DIALOG_TARGET_HEIGHT_PX = 520;
+// Target physical size of the Yivi dialog. Sized to fit the QR widget
+// (~290px wide) with comfortable margins, plus title, optional Safari
+// hint and Cancel button. We compute a screen-percentage from these at
+// runtime because Office.displayDialog only accepts percentages —
+// picking fixed percentages gives a tiny dialog on ultrawide monitors
+// and an oversized one on laptops.
+const YIVI_DIALOG_TARGET_WIDTH_PX = 460;
+const YIVI_DIALOG_TARGET_HEIGHT_PX = 640;
 
 // Flip to true to keep the Yivi dialog open after a successful encrypt
 // (and after an encryption error) instead of auto-closing. Useful when

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -70,6 +70,10 @@ const en: Bundle = {
   recipientUnknown: "This message was not encrypted for the mail account it was received on.",
 
   settingsTitle: "PostGuard Settings",
+  settingsPrefillTitle: "Sender attributes",
+  settingsPrefillHelp:
+    "These attributes are always offered when you sign a message. Fill in a value to make the disclosure mandatory (the Yivi app must match it). Leave blank to keep the attribute optional — you decide in the Yivi app at signing time.",
+  settingsAdvancedTitle: "Advanced",
   settingsAllowOptimisticDialogLabel: "Skip the “open a dialog” confirmation",
   settingsAllowOptimisticDialogHelp:
     "Off by default — Outlook shows a “PostGuard wants to open a dialog” prompt before each send. Turn this on only if you have already allowed pop-ups for this add-in in your browser’s site settings. Safari: Settings → Websites → Pop-ups → Allow for this site.",
@@ -79,6 +83,7 @@ const en: Bundle = {
   "pbdf.sidn-pbdf.email.email": "Email address",
   "pbdf.sidn-pbdf.mobilenumber.mobilenumber": "Mobile number",
   "pbdf.gemeente.personalData.surname": "Surname",
+  "pbdf.gemeente.personalData.fullname": "Name",
   "pbdf.gemeente.personalData.dateofbirth": "Date of birth",
 };
 
@@ -150,6 +155,10 @@ const nl: Bundle = {
     "Dit bericht is niet versleuteld voor het e-mailaccount waarop het is ontvangen.",
 
   settingsTitle: "PostGuard-instellingen",
+  settingsPrefillTitle: "Afzenderattributen",
+  settingsPrefillHelp:
+    "Deze attributen worden altijd aangeboden wanneer je een bericht ondertekent. Vul een waarde in om de onthulling verplicht te maken (de Yivi-app moet exact deze waarde tonen). Laat leeg om het attribuut optioneel te houden — dan beslis je in de Yivi-app of je het onthult.",
+  settingsAdvancedTitle: "Geavanceerd",
   settingsAllowOptimisticDialogLabel: "Sla de bevestiging “dialoogvenster openen” over",
   settingsAllowOptimisticDialogHelp:
     "Standaard uit — Outlook toont vóór elke verzending een melding “PostGuard wil een dialoogvenster openen”. Schakel dit alleen in als je pop-ups voor deze add-in al hebt toegestaan in de site-instellingen van je browser. Safari: Instellingen → Websites → Pop-upvensters → Toestaan voor deze site.",
@@ -159,6 +168,7 @@ const nl: Bundle = {
   "pbdf.sidn-pbdf.email.email": "E-mailadres",
   "pbdf.sidn-pbdf.mobilenumber.mobilenumber": "Mobiel nummer",
   "pbdf.gemeente.personalData.surname": "Achternaam",
+  "pbdf.gemeente.personalData.fullname": "Naam",
   "pbdf.gemeente.personalData.dateofbirth": "Geboortedatum",
 };
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -65,6 +65,13 @@ const en: Bundle = {
   sentCopyError: "Failed to save the sent copy of your encrypted message.",
   recipientUnknown: "This message was not encrypted for the mail account it was received on.",
 
+  settingsTitle: "PostGuard Settings",
+  settingsAllowOptimisticDialogLabel: "Skip the “open a dialog” confirmation",
+  settingsAllowOptimisticDialogHelp:
+    "Off by default — Outlook shows a “PostGuard wants to open a dialog” prompt before each send. Turn this on only if you have already allowed pop-ups for this add-in in your browser’s site settings. Safari: Settings → Websites → Pop-ups → Allow for this site.",
+  settingsBack: "Back",
+  settingsOpen: "Settings",
+
   "pbdf.sidn-pbdf.email.email": "Email address",
   "pbdf.sidn-pbdf.mobilenumber.mobilenumber": "Mobile number",
   "pbdf.gemeente.personalData.surname": "Surname",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -149,6 +149,13 @@ const nl: Bundle = {
   recipientUnknown:
     "Dit bericht is niet versleuteld voor het e-mailaccount waarop het is ontvangen.",
 
+  settingsTitle: "PostGuard-instellingen",
+  settingsAllowOptimisticDialogLabel: "Sla de bevestiging “dialoogvenster openen” over",
+  settingsAllowOptimisticDialogHelp:
+    "Standaard uit — Outlook toont vóór elke verzending een melding “PostGuard wil een dialoogvenster openen”. Schakel dit alleen in als je pop-ups voor deze add-in al hebt toegestaan in de site-instellingen van je browser. Safari: Instellingen → Websites → Pop-upvensters → Toestaan voor deze site.",
+  settingsBack: "Terug",
+  settingsOpen: "Instellingen",
+
   "pbdf.sidn-pbdf.email.email": "E-mailadres",
   "pbdf.sidn-pbdf.mobilenumber.mobilenumber": "Mobiel nummer",
   "pbdf.gemeente.personalData.surname": "Achternaam",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -78,6 +78,9 @@ const en: Bundle = {
   settingsAllowOptimisticDialogHelp:
     "Off by default — Outlook shows a “PostGuard wants to open a dialog” prompt before each send. Turn this on only if you have already allowed pop-ups for this add-in in your browser’s site settings. Safari: Settings → Websites → Pop-ups → Allow for this site.",
   settingsBack: "Back",
+  settingsSave: "Save",
+  settingsSaved: "Saved.",
+  settingsSaveError: "Could not save settings. Try again.",
   settingsOpen: "Settings",
 
   "pbdf.sidn-pbdf.email.email": "Email address",
@@ -163,6 +166,9 @@ const nl: Bundle = {
   settingsAllowOptimisticDialogHelp:
     "Standaard uit — Outlook toont vóór elke verzending een melding “PostGuard wil een dialoogvenster openen”. Schakel dit alleen in als je pop-ups voor deze add-in al hebt toegestaan in de site-instellingen van je browser. Safari: Instellingen → Websites → Pop-upvensters → Toestaan voor deze site.",
   settingsBack: "Terug",
+  settingsSave: "Opslaan",
+  settingsSaved: "Opgeslagen.",
+  settingsSaveError: "Instellingen konden niet worden opgeslagen. Probeer het opnieuw.",
   settingsOpen: "Instellingen",
 
   "pbdf.sidn-pbdf.email.email": "E-mailadres",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -4,6 +4,7 @@
 // reads).
 
 import { getSetting, setSetting } from "./storage";
+import { AttributeRequest } from "./types";
 
 // When true, the launchevent skips Office's "PostGuard wants to open a
 // dialog" confirmation and tries to open the Yivi dialog directly. Only
@@ -19,4 +20,51 @@ export function getAllowOptimisticDialog(): boolean {
 
 export function setAllowOptimisticDialog(value: boolean): Promise<void> {
   return setSetting<boolean>(ALLOW_OPTIMISTIC_DIALOG_KEY, value);
+}
+
+// Sign-attribute prefills. The three Yivi attribute types listed below are
+// always offered for disclosure when the user signs a message. If the user
+// has filled in a value in Settings, it is sent as a mandatory disclosure
+// (the Yivi app must match it). If the value is blank, the attribute is
+// sent as `optional: true` — the user discloses it in the Yivi app or
+// skips it.
+export const SIGN_PREFILL_FULLNAME = "pbdf.gemeente.personalData.fullname";
+export const SIGN_PREFILL_DATEOFBIRTH = "pbdf.gemeente.personalData.dateofbirth";
+export const SIGN_PREFILL_MOBILE = "pbdf.sidn-pbdf.mobilenumber.mobilenumber";
+export const SIGN_PREFILL_TYPES = [
+  SIGN_PREFILL_FULLNAME,
+  SIGN_PREFILL_DATEOFBIRTH,
+  SIGN_PREFILL_MOBILE,
+] as const;
+export type SignPrefillType = (typeof SIGN_PREFILL_TYPES)[number];
+
+const SIGN_PREFILLS_KEY = "pg.signPrefills";
+
+export function getSignPrefills(): Partial<Record<SignPrefillType, string>> {
+  const raw = getSetting<Partial<Record<SignPrefillType, string>>>(SIGN_PREFILLS_KEY, {});
+  // Defensive copy — roamingSettings returns the live object on subsequent
+  // reads and callers shouldn't mutate persisted state by accident.
+  return { ...raw };
+}
+
+export function setSignPrefills(values: Partial<Record<SignPrefillType, string>>): Promise<void> {
+  // Persist only the canonical keys; drop empty strings so a never-filled
+  // attribute stays "optional" rather than "mandatory with empty value".
+  const cleaned: Partial<Record<SignPrefillType, string>> = {};
+  for (const k of SIGN_PREFILL_TYPES) {
+    const v = (values[k] ?? "").trim();
+    if (v) cleaned[k] = v;
+  }
+  return setSetting(SIGN_PREFILLS_KEY, cleaned);
+}
+
+// Builds the attribute list passed to pg.sign.yivi({ attributes }). Each of
+// SIGN_PREFILL_TYPES is included exactly once: as a mandatory { t, v } when
+// the user prefilled a value, otherwise as { t, optional: true }.
+export function buildSignAttributes(): AttributeRequest[] {
+  const prefills = getSignPrefills();
+  return SIGN_PREFILL_TYPES.map((t) => {
+    const v = (prefills[t] ?? "").trim();
+    return v ? { t, v } : { t, optional: true };
+  });
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,22 @@
+// Typed wrappers around the roaming-settings keys used by the taskpane and
+// the OnMessageSend launchevent runtime. Keeping the key + default in one
+// place stops the two readers from drifting (taskpane writes, launchevent
+// reads).
+
+import { getSetting, setSetting } from "./storage";
+
+// When true, the launchevent skips Office's "PostGuard wants to open a
+// dialog" confirmation and tries to open the Yivi dialog directly. Only
+// works in browsers/hosts where the user has already granted popup
+// permission to the add-in's origin (Safari: Settings → Websites →
+// Pop-ups → Allow); elsewhere the optimistic attempt is blocked and the
+// launchevent falls back to the prompted open once.
+export const ALLOW_OPTIMISTIC_DIALOG_KEY = "pg.allowOptimisticDialog";
+
+export function getAllowOptimisticDialog(): boolean {
+  return getSetting<boolean>(ALLOW_OPTIMISTIC_DIALOG_KEY, false);
+}
+
+export function setAllowOptimisticDialog(value: boolean): Promise<void> {
+  return setSetting<boolean>(ALLOW_OPTIMISTIC_DIALOG_KEY, value);
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -40,11 +40,21 @@ export type SignPrefillType = (typeof SIGN_PREFILL_TYPES)[number];
 
 const SIGN_PREFILLS_KEY = "pg.signPrefills";
 
+// Module-level cache. Office's roamingSettings.get sometimes returns a stale
+// value inside the same runtime session even after a synchronous .set —
+// observed in WebView2 on new Outlook (save persists across page refresh
+// but get inside the same session reads the pre-set value). The cache is
+// populated on first read and overwritten synchronously by setSignPrefills,
+// so subsequent reads in the same session always reflect the latest write.
+let cachedPrefills: Partial<Record<SignPrefillType, string>> | null = null;
+
 export function getSignPrefills(): Partial<Record<SignPrefillType, string>> {
-  const raw = getSetting<Partial<Record<SignPrefillType, string>>>(SIGN_PREFILLS_KEY, {});
-  // Defensive copy — roamingSettings returns the live object on subsequent
-  // reads and callers shouldn't mutate persisted state by accident.
-  return { ...raw };
+  if (cachedPrefills === null) {
+    cachedPrefills = {
+      ...getSetting<Partial<Record<SignPrefillType, string>>>(SIGN_PREFILLS_KEY, {}),
+    };
+  }
+  return { ...cachedPrefills };
 }
 
 export function setSignPrefills(values: Partial<Record<SignPrefillType, string>>): Promise<void> {
@@ -55,6 +65,7 @@ export function setSignPrefills(values: Partial<Record<SignPrefillType, string>>
     const v = (values[k] ?? "").trim();
     if (v) cleaned[k] = v;
   }
+  cachedPrefills = { ...cleaned };
   return setSetting(SIGN_PREFILLS_KEY, cleaned);
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,10 @@
 // Persistent per-mailbox storage using Office roamingSettings.
 // roamingSettings is JSON-serializable, ~32KB total budget.
+//
+// saveAsync can fail with code 9019 ("GenericSettingsError: An internal
+// error has occurred.") when called rapidly in succession, which is what
+// the Settings prefill inputs triggered on every keystroke. We serialize
+// the saves through a single-flight queue and retry once on 9019.
 
 export function getSetting<T>(key: string, fallback: T): T {
   const v = Office.context.roamingSettings.get(key) as T | undefined;
@@ -8,20 +13,43 @@ export function getSetting<T>(key: string, fallback: T): T {
 
 export function setSetting<T>(key: string, value: T): Promise<void> {
   Office.context.roamingSettings.set(key, value);
-  return new Promise<void>((resolve, reject) => {
-    Office.context.roamingSettings.saveAsync((res) => {
-      if (res.status === Office.AsyncResultStatus.Succeeded) resolve();
-      else reject(res.error);
-    });
-  });
+  return enqueueSave();
 }
 
 export function removeSetting(key: string): Promise<void> {
   Office.context.roamingSettings.remove(key);
+  return enqueueSave();
+}
+
+let saveChain: Promise<void> = Promise.resolve();
+
+function enqueueSave(): Promise<void> {
+  const next = saveChain.catch(() => undefined).then(() => saveOnceWithRetry());
+  // The chain swallows errors on subsequent links so a single failed save
+  // doesn't poison the queue. The caller of setSetting / removeSetting
+  // still sees the failure via the returned promise.
+  saveChain = next.catch(() => undefined);
+  return next;
+}
+
+function saveOnceWithRetry(attempt = 0): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     Office.context.roamingSettings.saveAsync((res) => {
-      if (res.status === Office.AsyncResultStatus.Succeeded) resolve();
-      else reject(res.error);
+      if (res.status === Office.AsyncResultStatus.Succeeded) {
+        resolve();
+        return;
+      }
+      const code = (res.error as { code?: number } | undefined)?.code;
+      if (attempt < 2 && code === 9019) {
+        setTimeout(
+          () => {
+            saveOnceWithRetry(attempt + 1).then(resolve, reject);
+          },
+          150 * (attempt + 1)
+        );
+        return;
+      }
+      reject(res.error);
     });
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,11 @@
 
 export interface AttributeRequest {
   t: string;
-  v: string;
+  // Required disclosure value (Manage Access / recipient policies). Omit
+  // together with `optional: true` for sign-side attributes that the user
+  // may disclose at session time without a pre-specified value.
+  v?: string;
+  optional?: boolean;
 }
 
 export type AttributeCon = AttributeRequest[];

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -37,6 +37,11 @@ const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 // time. The handler compares this against the message's current recipients
 // to refuse sending an encrypted blob to anyone who wasn't in the policy.
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
+// JSON-encoded array of { t, optional: true } sign-attribute selections
+// captured from the taskpane. The launchevent runs in a separate WebView
+// and has no access to taskpane in-memory state, so the optional Yivi
+// disclosure list has to travel through an internet header.
+const HEADER_SIGN_ATTRIBUTES = "x-pg-sign-attributes";
 // PostGuard interop marker, written to outbound encrypted messages. The
 // Thunderbird addon writes the same header (background.ts:485) and uses it
 // as the OnMessageRead filter for the Outlook add-in. Detection on the
@@ -77,6 +82,20 @@ async function persistEncryptedRecipients(value: string | null): Promise<void> {
   } catch (_e) {
     // Best-effort. The handler also re-derives the current recipient list
     // and compares; a missing or stale header just biases toward blocking.
+  }
+}
+
+async function persistSignAttributes(value: AttributeRequest[]): Promise<void> {
+  try {
+    await saveItem();
+    if (value.length > 0) {
+      await setItemHeaders({ [HEADER_SIGN_ATTRIBUTES]: JSON.stringify(value) });
+    } else {
+      await removeItemHeaders([HEADER_SIGN_ATTRIBUTES]);
+    }
+    await saveItem();
+  } catch (e) {
+    console.error(`[pg] failed to persist signAttributes:`, e);
   }
 }
 
@@ -191,7 +210,7 @@ export async function mountComposeView(): Promise<void> {
   //             and persist "true" so the OnMessageSend handler sees the
   //             same intent the toggle visually shows.
   try {
-    const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND]);
+    const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND, HEADER_SIGN_ATTRIBUTES]);
     const v = headers[HEADER_ENCRYPT_ON_SEND];
     if (v === "true") {
       state.encrypt = true;
@@ -200,6 +219,19 @@ export async function mountComposeView(): Promise<void> {
     } else {
       state.encrypt = true;
       void persistEncryptOnSend(true);
+    }
+    const rawSign = headers[HEADER_SIGN_ATTRIBUTES];
+    if (rawSign) {
+      try {
+        const parsed = JSON.parse(rawSign) as AttributeRequest[];
+        if (Array.isArray(parsed)) {
+          state.signAttributes = parsed
+            .filter((a) => a && typeof a.t === "string")
+            .map((a) => ({ t: a.t, optional: true }));
+        }
+      } catch (_e) {
+        // Corrupt header — treat as empty.
+      }
     }
   } catch (_e) {
     // Header read failed — leave the default-on state alone.
@@ -280,6 +312,7 @@ function renderPolicyPanels(): void {
       state.signAttributes = (next[senderEmail] ?? [])
         .filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE)
         .map((a) => ({ t: a.t, optional: true }));
+      void persistSignAttributes(state.signAttributes);
     },
   });
 }

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -21,9 +21,10 @@ import {
 } from "../lib/office-helpers";
 import { toBase64 } from "../lib/encoding";
 import { EMAIL_ATTRIBUTE_TYPE } from "../lib/attributes";
-import { Policy, AttributeRequest, MimeAttachment } from "../lib/types";
+import { Policy, MimeAttachment } from "../lib/types";
 import { PKG_URL, CRYPTIFY_URL, POSTGUARD_WEBSITE_URL, clientHeaders } from "../lib/pkg-client";
 import { POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
+import { buildSignAttributes } from "../lib/settings";
 import { t } from "../lib/i18n";
 import { mountPolicyPanel } from "./policy-editor";
 import { showView, setStatus, showError } from "./taskpane";
@@ -37,11 +38,6 @@ const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 // time. The handler compares this against the message's current recipients
 // to refuse sending an encrypted blob to anyone who wasn't in the policy.
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
-// JSON-encoded array of { t, optional: true } sign-attribute selections
-// captured from the taskpane. The launchevent runs in a separate WebView
-// and has no access to taskpane in-memory state, so the optional Yivi
-// disclosure list has to travel through an internet header.
-const HEADER_SIGN_ATTRIBUTES = "x-pg-sign-attributes";
 // PostGuard interop marker, written to outbound encrypted messages. The
 // Thunderbird addon writes the same header (background.ts:485) and uses it
 // as the OnMessageRead filter for the Outlook add-in. Detection on the
@@ -85,20 +81,6 @@ async function persistEncryptedRecipients(value: string | null): Promise<void> {
   }
 }
 
-async function persistSignAttributes(value: AttributeRequest[]): Promise<void> {
-  try {
-    await saveItem();
-    if (value.length > 0) {
-      await setItemHeaders({ [HEADER_SIGN_ATTRIBUTES]: JSON.stringify(value) });
-    } else {
-      await removeItemHeaders([HEADER_SIGN_ATTRIBUTES]);
-    }
-    await saveItem();
-  } catch (e) {
-    console.error(`[pg] failed to persist signAttributes:`, e);
-  }
-}
-
 function recipientsKey(): string {
   return [...state.recipients.to, ...state.recipients.cc]
     .map((e) => e.toLowerCase().trim())
@@ -110,7 +92,6 @@ function recipientsKey(): string {
 interface ComposeState {
   encrypt: boolean;
   policy: Policy;
-  signAttributes: AttributeRequest[];
   recipients: { to: string[]; cc: string[]; bcc: string[] };
   busy: boolean;
   // Set after a successful encrypt run; used to label the action button
@@ -134,7 +115,6 @@ interface ComposeState {
 const state: ComposeState = {
   encrypt: true,
   policy: {},
-  signAttributes: [],
   recipients: { to: [], cc: [], bcc: [] },
   busy: false,
   encrypted: false,
@@ -146,13 +126,14 @@ const state: ComposeState = {
 
 // Stringified form of everything that affects the encrypted output. If this
 // changes after a successful encrypt, the message no longer matches the
-// current intent and Re-encrypt should be enabled.
+// current intent and Re-encrypt should be enabled. Sender attributes are
+// configured in Settings (roaming) and don't participate here — changing a
+// prefill doesn't invalidate the already-sealed message.
 function relevantStateString(): string {
   return JSON.stringify({
     to: [...state.recipients.to].sort(),
     cc: [...state.recipients.cc].sort(),
     policy: state.policy,
-    sign: state.signAttributes,
   });
 }
 
@@ -162,11 +143,9 @@ export async function mountComposeView(): Promise<void> {
   const toggle = byId<HTMLInputElement>("pg-toggle-encrypt");
   const bccWarning = byId<HTMLElement>("pg-bcc-warning");
   const manageTitle = byId<HTMLElement>("pg-manage-title");
-  const signTitle = byId<HTMLElement>("pg-sign-title");
   const btnEncryptSend = byId<HTMLButtonElement>("pg-btn-encrypt-send");
 
   manageTitle.textContent = t("manageAccess");
-  signTitle.textContent = t("sign");
   btnEncryptSend.textContent = t("encryptAndSend");
 
   // The Encrypt & Send button is the Mac-only workaround for the
@@ -210,7 +189,7 @@ export async function mountComposeView(): Promise<void> {
   //             and persist "true" so the OnMessageSend handler sees the
   //             same intent the toggle visually shows.
   try {
-    const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND, HEADER_SIGN_ATTRIBUTES]);
+    const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND]);
     const v = headers[HEADER_ENCRYPT_ON_SEND];
     if (v === "true") {
       state.encrypt = true;
@@ -219,19 +198,6 @@ export async function mountComposeView(): Promise<void> {
     } else {
       state.encrypt = true;
       void persistEncryptOnSend(true);
-    }
-    const rawSign = headers[HEADER_SIGN_ATTRIBUTES];
-    if (rawSign) {
-      try {
-        const parsed = JSON.parse(rawSign) as AttributeRequest[];
-        if (Array.isArray(parsed)) {
-          state.signAttributes = parsed
-            .filter((a) => a && typeof a.t === "string")
-            .map((a) => ({ t: a.t, optional: true }));
-        }
-      } catch (_e) {
-        // Corrupt header — treat as empty.
-      }
     }
   } catch (_e) {
     // Header read failed — leave the default-on state alone.
@@ -258,61 +224,33 @@ export async function mountComposeView(): Promise<void> {
 
 function renderPolicyPanels(): void {
   const manageSection = byId<HTMLElement>("pg-manage-section");
-  const signSection = byId<HTMLElement>("pg-sign-section");
   const manageContainer = byId<HTMLElement>("pg-manage-panel");
-  const signContainer = byId<HTMLElement>("pg-sign-panel");
 
-  // When encryption is off, the policies don't apply — collapse both
-  // sections so the compose view stays uncluttered.
+  // When encryption is off the recipient policy doesn't apply — collapse
+  // the section so the compose view stays uncluttered. Sender attributes
+  // are configured in Settings now, not here.
   if (!state.encrypt) {
     manageSection.hidden = true;
-    signSection.hidden = true;
     return;
   }
   manageSection.hidden = false;
-  signSection.hidden = false;
 
   const recipients = [...state.recipients.to, ...state.recipients.cc];
   if (recipients.length === 0) {
     manageContainer.innerHTML = `<p class="pg-subtitle">${t("composeNoRecipients")}</p>`;
-  } else {
-    mountPolicyPanel(manageContainer, {
-      emails: recipients,
-      initialPolicy: state.policy,
-      onChange: (next) => {
-        state.policy = next;
-        // Ensure email is always populated even if the user managed to clear it.
-        for (const [email, attrs] of Object.entries(state.policy)) {
-          if (!attrs.some((a) => a.t === EMAIL_ATTRIBUTE_TYPE)) {
-            attrs.unshift({ t: EMAIL_ATTRIBUTE_TYPE, v: email });
-          }
-        }
-      },
-    });
-  }
-
-  const senderEmail = getSenderEmail();
-  if (!senderEmail) {
-    signContainer.innerHTML = "";
     return;
   }
-  // Sign editor is conceptually a single-recipient policy where the
-  // "recipient" is the sender's own address.
-  const signInitial: Policy = {
-    [senderEmail]: [{ t: EMAIL_ATTRIBUTE_TYPE, v: senderEmail }, ...state.signAttributes],
-  };
-  mountPolicyPanel(signContainer, {
-    emails: [senderEmail],
-    initialPolicy: signInitial,
-    mode: "sign",
+  mountPolicyPanel(manageContainer, {
+    emails: recipients,
+    initialPolicy: state.policy,
     onChange: (next) => {
-      // signAttributes stores ONLY extras as optional disclosures. pg.sign.yivi
-      // already takes senderEmail as a top-level field; including email here
-      // as well triggers a second email disclosure on the Yivi QR.
-      state.signAttributes = (next[senderEmail] ?? [])
-        .filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE)
-        .map((a) => ({ t: a.t, optional: true }));
-      void persistSignAttributes(state.signAttributes);
+      state.policy = next;
+      // Ensure email is always populated even if the user managed to clear it.
+      for (const [email, attrs] of Object.entries(state.policy)) {
+        if (!attrs.some((a) => a.t === EMAIL_ATTRIBUTE_TYPE)) {
+          attrs.unshift({ t: EMAIL_ATTRIBUTE_TYPE, v: email });
+        }
+      }
     },
   });
 }
@@ -459,16 +397,18 @@ async function encryptAndPrepareSend(): Promise<void> {
 
     const recipients = buildPgRecipients(pg);
 
+    // Sign attributes come from Settings (per-mailbox roaming setting),
+    // not per-draft state. Prefilled values become { t, v } (mandatory);
+    // blank prefills become { t, optional: true } so the user can decide
+    // inside the Yivi app at session time. Fixes #49 / #56.
+    const signAttributes = buildSignAttributes();
+
     const sealed = pg.encrypt({
       sign: pg.sign.yivi({
         element: "#yivi-web-form",
         senderEmail,
         includeSender: true,
-        // Match the postguard-website pattern: each entry is { t, optional: true }
-        // so the user discloses values inside the Yivi app at session time. No
-        // pre-typed values means signing no longer fails when the user's Yivi
-        // credentials don't match a guessed string (#49, #56).
-        attributes: state.signAttributes.length ? state.signAttributes : undefined,
+        attributes: signAttributes,
       } as never),
       recipients,
       data: mime,

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -272,11 +272,14 @@ function renderPolicyPanels(): void {
   mountPolicyPanel(signContainer, {
     emails: [senderEmail],
     initialPolicy: signInitial,
+    mode: "sign",
     onChange: (next) => {
-      // signAttributes stores ONLY extras. pg.sign.yivi already takes
-      // senderEmail as a top-level field; including email here as well
-      // triggers a second email disclosure on the Yivi QR.
-      state.signAttributes = (next[senderEmail] ?? []).filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE);
+      // signAttributes stores ONLY extras as optional disclosures. pg.sign.yivi
+      // already takes senderEmail as a top-level field; including email here
+      // as well triggers a second email disclosure on the Yivi QR.
+      state.signAttributes = (next[senderEmail] ?? [])
+        .filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE)
+        .map((a) => ({ t: a.t, optional: true }));
     },
   });
 }
@@ -427,6 +430,11 @@ async function encryptAndPrepareSend(): Promise<void> {
       sign: pg.sign.yivi({
         element: "#yivi-web-form",
         senderEmail,
+        includeSender: true,
+        // Match the postguard-website pattern: each entry is { t, optional: true }
+        // so the user discloses values inside the Yivi app at session time. No
+        // pre-typed values means signing no longer fails when the user's Yivi
+        // credentials don't match a guessed string (#49, #56).
         attributes: state.signAttributes.length ? state.signAttributes : undefined,
       } as never),
       recipients,
@@ -436,11 +444,15 @@ async function encryptAndPrepareSend(): Promise<void> {
     // pg-js 1.2.0+: the Cryptify upload is silent by default, so we
     // can let it run for tier 2/3 — the recipient sees a download link
     // in the body but no duplicate mail from Cryptify.
+    //
+    // senderAttributes is a display-only hint for the envelope template.
+    // With optional sign attributes we don't know the disclosed values
+    // until after the Yivi session, so we leave it unset — the SDK falls
+    // back to whatever the signed envelope itself carries.
     const envelope = await pg.email.createEnvelope({
       sealed,
       from: senderEmail,
       websiteUrl: POSTGUARD_WEBSITE_URL,
-      senderAttributes: state.signAttributes.map((a) => a.v),
     } as never);
 
     await setSubject(envelope.subject);

--- a/src/taskpane/policy-editor.ts
+++ b/src/taskpane/policy-editor.ts
@@ -16,24 +16,40 @@ interface PolicyPanelOptions {
   emails: string[];
   initialPolicy: Policy;
   onChange: (next: Policy) => void;
+  // "manage" (default): recipient-side required disclosure — rows have
+  // value inputs and are filtered out of the result when empty.
+  // "sign": sender-side optional disclosure — selected attributes render
+  // as chips with no value input; result entries are { t, optional: true }.
+  mode?: "manage" | "sign";
 }
 
 export function mountPolicyPanel(container: HTMLElement, opts: PolicyPanelOptions): void {
+  const mode = opts.mode ?? "manage";
+
   // Working state for this panel — extras only (email is implicit).
   const working = new Map<string, AttributeRequest[]>();
   for (const email of opts.emails) {
     const attrs = opts.initialPolicy[email] ?? [];
     const extras = attrs
       .filter((a) => a.t !== EMAIL_ATTRIBUTE_TYPE)
-      .map((a) => ({ t: a.t, v: a.v }));
+      .map((a) => (mode === "sign" ? { t: a.t, optional: true } : { t: a.t, v: a.v ?? "" }));
     working.set(email, extras);
   }
 
   const fireChange = () => {
     const result: Policy = {};
     for (const [email, extras] of working.entries()) {
-      const valid = extras.map((a) => ({ t: a.t, v: a.v.trim() })).filter((a) => a.v.length > 0);
-      result[email] = [{ t: EMAIL_ATTRIBUTE_TYPE, v: email }, ...valid];
+      if (mode === "sign") {
+        result[email] = [
+          { t: EMAIL_ATTRIBUTE_TYPE, v: email },
+          ...extras.map((a) => ({ t: a.t, optional: true })),
+        ];
+      } else {
+        const valid = extras
+          .map((a) => ({ t: a.t, v: (a.v ?? "").trim() }))
+          .filter((a) => a.v.length > 0);
+        result[email] = [{ t: EMAIL_ATTRIBUTE_TYPE, v: email }, ...valid];
+      }
     }
     opts.onChange(result);
   };
@@ -44,7 +60,7 @@ export function mountPolicyPanel(container: HTMLElement, opts: PolicyPanelOption
   const wrapper = document.createElement("div");
   wrapper.className = "pg-policy-recipients";
   for (const email of working.keys()) {
-    wrapper.appendChild(renderRecipient(working, email, fireChange));
+    wrapper.appendChild(renderRecipient(working, email, fireChange, mode));
   }
   container.appendChild(wrapper);
 }
@@ -52,12 +68,13 @@ export function mountPolicyPanel(container: HTMLElement, opts: PolicyPanelOption
 function renderRecipient(
   working: Map<string, AttributeRequest[]>,
   email: string,
-  fireChange: () => void
+  fireChange: () => void,
+  mode: "manage" | "sign"
 ): HTMLElement {
   const section = document.createElement("div");
   section.className = "pg-policy-recipient";
   section.dataset.email = email;
-  rerenderRecipient(working, section, email, fireChange);
+  rerenderRecipient(working, section, email, fireChange, mode);
   return section;
 }
 
@@ -65,7 +82,8 @@ function rerenderRecipient(
   working: Map<string, AttributeRequest[]>,
   section: HTMLElement,
   email: string,
-  fireChange: () => void
+  fireChange: () => void,
+  mode: "manage" | "sign"
 ): void {
   const extras = working.get(email)!;
   section.innerHTML = "";
@@ -75,21 +93,43 @@ function rerenderRecipient(
   heading.textContent = email;
   section.appendChild(heading);
 
-  for (let i = 0; i < extras.length; i++) {
-    const desc = SUPPORTED_ATTRIBUTES.find((d) => d.type === extras[i].t);
-    if (!desc) continue;
-    section.appendChild(
-      renderAttrRow(
-        extras,
-        i,
-        desc,
-        () => {
-          rerenderRecipient(working, section, email, fireChange);
-          fireChange();
-        },
-        fireChange
-      )
-    );
+  if (mode === "sign") {
+    // Sign mode: render selected attributes as filled chips; the user
+    // discloses values inside the Yivi app at session time, no value
+    // inputs in the taskpane. Empty list is a valid state (email-only
+    // signing).
+    if (extras.length > 0) {
+      const chipRow = document.createElement("div");
+      chipRow.className = "pg-policy-add-row";
+      for (let i = 0; i < extras.length; i++) {
+        const desc = SUPPORTED_ATTRIBUTES.find((d) => d.type === extras[i].t);
+        if (!desc) continue;
+        chipRow.appendChild(
+          renderSelectedChip(extras, i, desc, () => {
+            rerenderRecipient(working, section, email, fireChange, mode);
+            fireChange();
+          })
+        );
+      }
+      section.appendChild(chipRow);
+    }
+  } else {
+    for (let i = 0; i < extras.length; i++) {
+      const desc = SUPPORTED_ATTRIBUTES.find((d) => d.type === extras[i].t);
+      if (!desc) continue;
+      section.appendChild(
+        renderAttrRow(
+          extras,
+          i,
+          desc,
+          () => {
+            rerenderRecipient(working, section, email, fireChange, mode);
+            fireChange();
+          },
+          fireChange
+        )
+      );
+    }
   }
 
   const addable = SUPPORTED_ATTRIBUTES.filter(
@@ -104,14 +144,44 @@ function rerenderRecipient(
       btn.className = "pg-policy-add-chip";
       btn.textContent = `+ ${t(desc.type, desc.defaultLabel)}`;
       btn.addEventListener("click", () => {
-        extras.push({ t: desc.type, v: "" });
-        rerenderRecipient(working, section, email, fireChange);
+        extras.push(mode === "sign" ? { t: desc.type, optional: true } : { t: desc.type, v: "" });
+        rerenderRecipient(working, section, email, fireChange, mode);
         fireChange();
       });
       addRow.appendChild(btn);
     }
     section.appendChild(addRow);
   }
+}
+
+function renderSelectedChip(
+  extras: AttributeRequest[],
+  index: number,
+  desc: AttributeDescriptor,
+  onDelete: () => void
+): HTMLElement {
+  const chip = document.createElement("span");
+  chip.className = "pg-policy-selected-chip";
+
+  const label = document.createElement("span");
+  label.textContent = t(desc.type, desc.defaultLabel);
+  chip.appendChild(label);
+
+  const remove = document.createElement("button");
+  remove.type = "button";
+  remove.className = "pg-policy-selected-chip-remove";
+  remove.setAttribute(
+    "aria-label",
+    `${t("removeRecipient", "Remove")} ${t(desc.type, desc.defaultLabel)}`
+  );
+  remove.textContent = "×";
+  remove.addEventListener("click", () => {
+    extras.splice(index, 1);
+    onDelete();
+  });
+  chip.appendChild(remove);
+
+  return chip;
 }
 
 function renderAttrRow(
@@ -144,7 +214,7 @@ function renderAttrRow(
     // Round-trip through helpers so the IBE identity at encrypt matches what
     // Yivi discloses at decrypt.
     input.type = "date";
-    input.value = ddmmyyyyToHtml(attr.v);
+    input.value = ddmmyyyyToHtml(attr.v ?? "");
     input.addEventListener("input", () => {
       attr.v = htmlToDdmmyyyy(input.value);
       fireChange();
@@ -155,14 +225,14 @@ function renderAttrRow(
     // simply fail at decrypt — better than silently rewriting input.
     input.type = "tel";
     input.placeholder = "+31612345678";
-    input.value = attr.v;
+    input.value = attr.v ?? "";
     input.addEventListener("input", () => {
       attr.v = input.value;
       fireChange();
     });
   } else {
     input.type = "text";
-    input.value = attr.v;
+    input.value = attr.v ?? "";
     input.addEventListener("input", () => {
       attr.v = input.value;
       fireChange();

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -2,6 +2,10 @@
 // for fullname / DOB / mobile) and the advanced "skip the open-a-dialog
 // confirmation" toggle. All values are persisted to roamingSettings so
 // the OnMessageSend launchevent runtime can read them too.
+//
+// Prefills require an explicit Save click — auto-saving on `change` (blur)
+// lost data when the user clicked Back without blurring the field first.
+// The toggle still saves immediately because it's a single discrete click.
 
 import {
   SIGN_PREFILL_FULLNAME,
@@ -17,9 +21,7 @@ import { t } from "../lib/i18n";
 import { showView, setStatus, ViewName } from "./taskpane";
 
 export function mountSettingsView(returnTo: ViewName): void {
-  const title = byId<HTMLElement>("pg-settings-title");
-  title.textContent = t("settingsTitle");
-
+  byId<HTMLElement>("pg-settings-title").textContent = t("settingsTitle");
   byId<HTMLElement>("pg-settings-prefill-title").textContent = t("settingsPrefillTitle");
   byId<HTMLElement>("pg-settings-prefill-help").textContent = t("settingsPrefillHelp");
   byId<HTMLElement>("pg-settings-advanced-title").textContent = t("settingsAdvancedTitle");
@@ -29,7 +31,6 @@ export function mountSettingsView(returnTo: ViewName): void {
   byId<HTMLElement>("pg-settings-optimistic-help").textContent = t(
     "settingsAllowOptimisticDialogHelp"
   );
-
   byId<HTMLElement>("pg-prefill-fullname-label").textContent = t(SIGN_PREFILL_FULLNAME);
   byId<HTMLElement>("pg-prefill-dateofbirth-label").textContent = t(SIGN_PREFILL_DATEOFBIRTH);
   byId<HTMLElement>("pg-prefill-mobile-label").textContent = t(SIGN_PREFILL_MOBILE);
@@ -45,40 +46,40 @@ export function mountSettingsView(returnTo: ViewName): void {
   );
   const mobile = freshInput("pg-prefill-mobile", prefills[SIGN_PREFILL_MOBILE] ?? "");
 
-  const save = async (key: SignPrefillType, value: string): Promise<void> => {
-    const merged = { ...getSignPrefills(), [key]: value };
-    try {
-      await setSignPrefills(merged);
-    } catch (err) {
-      console.error("[pg-settings] failed to persist prefill", key, err);
-      setStatus("Could not save setting. Try again.", "error");
-    }
-  };
-
-  // Persist on `change` (blur) rather than `input` (every keystroke).
-  // roamingSettings.saveAsync intermittently fails with code 9019
-  // ("GenericSettingsError") when fired rapidly in succession; debouncing
-  // at the source removes the churn entirely.
-  fullname.addEventListener("change", () => void save(SIGN_PREFILL_FULLNAME, fullname.value));
-  dob.addEventListener(
-    "change",
-    () => void save(SIGN_PREFILL_DATEOFBIRTH, htmlToDdmmyyyy(dob.value))
-  );
-  mobile.addEventListener("change", () => void save(SIGN_PREFILL_MOBILE, mobile.value));
-
+  // The advanced toggle is a single discrete click; persisting immediately
+  // keeps the UX simple and the value won't be lost on Back.
   const toggle = freshCheckbox("pg-toggle-allow-optimistic-dialog", getAllowOptimisticDialog());
   toggle.addEventListener("change", () => {
     void setAllowOptimisticDialog(toggle.checked).catch((err) => {
       console.error("[pg-settings] failed to persist toggle", err);
-      setStatus("Could not save setting. Try again.", "error");
+      setStatus(t("settingsSaveError"), "error");
     });
   });
 
-  const back = byId<HTMLButtonElement>("pg-settings-back");
-  back.textContent = t("settingsBack");
-  const freshBack = back.cloneNode(true) as HTMLButtonElement;
-  back.replaceWith(freshBack);
-  freshBack.addEventListener("click", () => {
+  const save = freshButton("pg-settings-save", t("settingsSave"));
+  save.addEventListener("click", () => {
+    save.disabled = true;
+    const next: Partial<Record<SignPrefillType, string>> = {
+      [SIGN_PREFILL_FULLNAME]: fullname.value,
+      [SIGN_PREFILL_DATEOFBIRTH]: htmlToDdmmyyyy(dob.value),
+      [SIGN_PREFILL_MOBILE]: mobile.value,
+    };
+    setSignPrefills(next)
+      .then(() => {
+        setStatus(t("settingsSaved"));
+        setTimeout(() => setStatus(""), 2000);
+      })
+      .catch((err) => {
+        console.error("[pg-settings] failed to persist prefills", err);
+        setStatus(t("settingsSaveError"), "error");
+      })
+      .finally(() => {
+        save.disabled = false;
+      });
+  });
+
+  const back = freshButton("pg-settings-back", t("settingsBack"));
+  back.addEventListener("click", () => {
     setStatus("");
     showView(returnTo);
   });
@@ -92,9 +93,9 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-// Clone-replace the input so any listeners attached during a previous
-// mountSettingsView call are dropped before we add new ones — the view
-// is re-mountable from the gear button at any time.
+// Clone-replace so listeners attached during a previous mountSettingsView
+// call are dropped before we add new ones — the view is re-mountable from
+// the footer Settings button at any time.
 function freshInput(id: string, value: string): HTMLInputElement {
   const stale = byId<HTMLInputElement>(id);
   const fresh = stale.cloneNode(true) as HTMLInputElement;
@@ -107,6 +108,15 @@ function freshCheckbox(id: string, checked: boolean): HTMLInputElement {
   const stale = byId<HTMLInputElement>(id);
   const fresh = stale.cloneNode(true) as HTMLInputElement;
   fresh.checked = checked;
+  stale.replaceWith(fresh);
+  return fresh;
+}
+
+function freshButton(id: string, label: string): HTMLButtonElement {
+  const stale = byId<HTMLButtonElement>(id);
+  const fresh = stale.cloneNode(true) as HTMLButtonElement;
+  fresh.textContent = label;
+  fresh.disabled = false;
   stale.replaceWith(fresh);
   return fresh;
 }

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -3,9 +3,10 @@
 // confirmation" toggle. All values are persisted to roamingSettings so
 // the OnMessageSend launchevent runtime can read them too.
 //
-// Prefills require an explicit Save click — auto-saving on `change` (blur)
-// lost data when the user clicked Back without blurring the field first.
-// The toggle still saves immediately because it's a single discrete click.
+// Listeners are attached exactly once on first mount (tracked via the
+// `wired` flag). Subsequent mounts only refresh the input values from
+// roamingSettings — no DOM cloning, which avoids the browser-specific
+// cloneNode-with-input.value quirks the previous implementation hit.
 
 import {
   SIGN_PREFILL_FULLNAME,
@@ -20,7 +21,21 @@ import {
 import { t } from "../lib/i18n";
 import { showView, setStatus, ViewName } from "./taskpane";
 
+let wired = false;
+let returnView: ViewName = "compose";
+
 export function mountSettingsView(returnTo: ViewName): void {
+  returnView = returnTo;
+  refreshLabels();
+  refreshValues();
+  if (!wired) {
+    wireListeners();
+    wired = true;
+  }
+  showView("settings");
+}
+
+function refreshLabels(): void {
   byId<HTMLElement>("pg-settings-title").textContent = t("settingsTitle");
   byId<HTMLElement>("pg-settings-prefill-title").textContent = t("settingsPrefillTitle");
   byId<HTMLElement>("pg-settings-prefill-help").textContent = t("settingsPrefillHelp");
@@ -34,43 +49,47 @@ export function mountSettingsView(returnTo: ViewName): void {
   byId<HTMLElement>("pg-prefill-fullname-label").textContent = t(SIGN_PREFILL_FULLNAME);
   byId<HTMLElement>("pg-prefill-dateofbirth-label").textContent = t(SIGN_PREFILL_DATEOFBIRTH);
   byId<HTMLElement>("pg-prefill-mobile-label").textContent = t(SIGN_PREFILL_MOBILE);
+  byId<HTMLButtonElement>("pg-settings-save").textContent = t("settingsSave");
+  byId<HTMLButtonElement>("pg-settings-back").textContent = t("settingsBack");
+}
 
+function refreshValues(): void {
   const prefills = getSignPrefills();
-  // DOB is stored as DD-MM-YYYY (Yivi's format); <input type="date"> uses
-  // YYYY-MM-DD. Round-trip through the same helpers the policy editor
-  // uses for the Manage Access date input.
-  const fullname = freshInput("pg-prefill-fullname", prefills[SIGN_PREFILL_FULLNAME] ?? "");
-  const dob = freshInput(
-    "pg-prefill-dateofbirth",
-    ddmmyyyyToHtml(prefills[SIGN_PREFILL_DATEOFBIRTH] ?? "")
+  byId<HTMLInputElement>("pg-prefill-fullname").value = prefills[SIGN_PREFILL_FULLNAME] ?? "";
+  byId<HTMLInputElement>("pg-prefill-dateofbirth").value = ddmmyyyyToHtml(
+    prefills[SIGN_PREFILL_DATEOFBIRTH] ?? ""
   );
-  const mobile = freshInput("pg-prefill-mobile", prefills[SIGN_PREFILL_MOBILE] ?? "");
+  byId<HTMLInputElement>("pg-prefill-mobile").value = prefills[SIGN_PREFILL_MOBILE] ?? "";
+  byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog").checked = getAllowOptimisticDialog();
+  byId<HTMLButtonElement>("pg-settings-save").disabled = false;
+}
 
-  // The advanced toggle is a single discrete click; persisting immediately
-  // keeps the UX simple and the value won't be lost on Back.
-  const toggle = freshCheckbox("pg-toggle-allow-optimistic-dialog", getAllowOptimisticDialog());
-  toggle.addEventListener("change", () => {
-    void setAllowOptimisticDialog(toggle.checked).catch((err) => {
+function wireListeners(): void {
+  byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog").addEventListener("change", () => {
+    const checked = byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog").checked;
+    void setAllowOptimisticDialog(checked).catch((err) => {
       console.error("[pg-settings] failed to persist toggle", err);
       setStatus(t("settingsSaveError"), "error");
     });
   });
 
-  const save = freshButton("pg-settings-save", t("settingsSave"));
-  save.addEventListener("click", () => {
+  byId<HTMLButtonElement>("pg-settings-save").addEventListener("click", () => {
+    const save = byId<HTMLButtonElement>("pg-settings-save");
     save.disabled = true;
     const next: Partial<Record<SignPrefillType, string>> = {
-      [SIGN_PREFILL_FULLNAME]: fullname.value,
-      [SIGN_PREFILL_DATEOFBIRTH]: htmlToDdmmyyyy(dob.value),
-      [SIGN_PREFILL_MOBILE]: mobile.value,
+      [SIGN_PREFILL_FULLNAME]: byId<HTMLInputElement>("pg-prefill-fullname").value,
+      [SIGN_PREFILL_DATEOFBIRTH]: htmlToDdmmyyyy(
+        byId<HTMLInputElement>("pg-prefill-dateofbirth").value
+      ),
+      [SIGN_PREFILL_MOBILE]: byId<HTMLInputElement>("pg-prefill-mobile").value,
     };
+    console.log("[pg-settings] saving prefills:", next);
     setSignPrefills(next)
       .then(() => {
-        // Status banner lives outside the view sections so the user sees
-        // "Saved." on whichever view we return to.
+        console.log("[pg-settings] persisted; readback:", getSignPrefills());
         setStatus(t("settingsSaved"));
         setTimeout(() => setStatus(""), 2000);
-        showView(returnTo);
+        showView(returnView);
       })
       .catch((err) => {
         console.error("[pg-settings] failed to persist prefills", err);
@@ -79,47 +98,16 @@ export function mountSettingsView(returnTo: ViewName): void {
       });
   });
 
-  const back = freshButton("pg-settings-back", t("settingsBack"));
-  back.addEventListener("click", () => {
+  byId<HTMLButtonElement>("pg-settings-back").addEventListener("click", () => {
     setStatus("");
-    showView(returnTo);
+    showView(returnView);
   });
-
-  showView("settings");
 }
 
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
-}
-
-// Clone-replace so listeners attached during a previous mountSettingsView
-// call are dropped before we add new ones — the view is re-mountable from
-// the footer Settings button at any time.
-function freshInput(id: string, value: string): HTMLInputElement {
-  const stale = byId<HTMLInputElement>(id);
-  const fresh = stale.cloneNode(true) as HTMLInputElement;
-  fresh.value = value;
-  stale.replaceWith(fresh);
-  return fresh;
-}
-
-function freshCheckbox(id: string, checked: boolean): HTMLInputElement {
-  const stale = byId<HTMLInputElement>(id);
-  const fresh = stale.cloneNode(true) as HTMLInputElement;
-  fresh.checked = checked;
-  stale.replaceWith(fresh);
-  return fresh;
-}
-
-function freshButton(id: string, label: string): HTMLButtonElement {
-  const stale = byId<HTMLButtonElement>(id);
-  const fresh = stale.cloneNode(true) as HTMLButtonElement;
-  fresh.textContent = label;
-  fresh.disabled = false;
-  stale.replaceWith(fresh);
-  return fresh;
 }
 
 function ddmmyyyyToHtml(ddmmyyyy: string): string {

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -1,37 +1,77 @@
-// Settings view: a single roaming-settings-backed toggle for the
-// "skip the open-a-dialog confirmation" preference, with a Back button
-// that returns to whichever view opened it.
+// Settings view: sender-attribute prefills (mandatory disclosure values
+// for fullname / DOB / mobile) and the advanced "skip the open-a-dialog
+// confirmation" toggle. All values are persisted to roamingSettings so
+// the OnMessageSend launchevent runtime can read them too.
 
-import { getAllowOptimisticDialog, setAllowOptimisticDialog } from "../lib/settings";
+import {
+  SIGN_PREFILL_FULLNAME,
+  SIGN_PREFILL_DATEOFBIRTH,
+  SIGN_PREFILL_MOBILE,
+  SignPrefillType,
+  getAllowOptimisticDialog,
+  getSignPrefills,
+  setAllowOptimisticDialog,
+  setSignPrefills,
+} from "../lib/settings";
 import { t } from "../lib/i18n";
 import { showView, setStatus, ViewName } from "./taskpane";
 
 export function mountSettingsView(returnTo: ViewName): void {
   const title = byId<HTMLElement>("pg-settings-title");
-  const label = byId<HTMLElement>("pg-settings-optimistic-label");
-  const help = byId<HTMLElement>("pg-settings-optimistic-help");
-  const toggle = byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog");
-  const back = byId<HTMLButtonElement>("pg-settings-back");
-
   title.textContent = t("settingsTitle");
-  label.textContent = t("settingsAllowOptimisticDialogLabel");
-  help.textContent = t("settingsAllowOptimisticDialogHelp");
-  back.textContent = t("settingsBack");
 
-  toggle.checked = getAllowOptimisticDialog();
+  byId<HTMLElement>("pg-settings-prefill-title").textContent = t("settingsPrefillTitle");
+  byId<HTMLElement>("pg-settings-prefill-help").textContent = t("settingsPrefillHelp");
+  byId<HTMLElement>("pg-settings-advanced-title").textContent = t("settingsAdvancedTitle");
+  byId<HTMLElement>("pg-settings-optimistic-label").textContent = t(
+    "settingsAllowOptimisticDialogLabel"
+  );
+  byId<HTMLElement>("pg-settings-optimistic-help").textContent = t(
+    "settingsAllowOptimisticDialogHelp"
+  );
 
-  // Replace any listeners from a previous mount by cloning. The settings
-  // view is re-mountable from multiple entry points (compose, read), so
-  // we cannot rely on a single addEventListener call per app lifetime.
-  const freshToggle = toggle.cloneNode(true) as HTMLInputElement;
-  toggle.replaceWith(freshToggle);
-  freshToggle.addEventListener("change", () => {
-    void setAllowOptimisticDialog(freshToggle.checked).catch((err) => {
+  byId<HTMLElement>("pg-prefill-fullname-label").textContent = t(SIGN_PREFILL_FULLNAME);
+  byId<HTMLElement>("pg-prefill-dateofbirth-label").textContent = t(SIGN_PREFILL_DATEOFBIRTH);
+  byId<HTMLElement>("pg-prefill-mobile-label").textContent = t(SIGN_PREFILL_MOBILE);
+
+  const prefills = getSignPrefills();
+  // DOB is stored as DD-MM-YYYY (Yivi's format); <input type="date"> uses
+  // YYYY-MM-DD. Round-trip through the same helpers the policy editor
+  // uses for the Manage Access date input.
+  const fullname = freshInput("pg-prefill-fullname", prefills[SIGN_PREFILL_FULLNAME] ?? "");
+  const dob = freshInput(
+    "pg-prefill-dateofbirth",
+    ddmmyyyyToHtml(prefills[SIGN_PREFILL_DATEOFBIRTH] ?? "")
+  );
+  const mobile = freshInput("pg-prefill-mobile", prefills[SIGN_PREFILL_MOBILE] ?? "");
+
+  const save = async (key: SignPrefillType, value: string): Promise<void> => {
+    const merged = { ...getSignPrefills(), [key]: value };
+    try {
+      await setSignPrefills(merged);
+    } catch (err) {
+      console.error("[pg-settings] failed to persist prefill", key, err);
+      setStatus("Could not save setting. Try again.", "error");
+    }
+  };
+
+  fullname.addEventListener("input", () => void save(SIGN_PREFILL_FULLNAME, fullname.value));
+  dob.addEventListener(
+    "input",
+    () => void save(SIGN_PREFILL_DATEOFBIRTH, htmlToDdmmyyyy(dob.value))
+  );
+  mobile.addEventListener("input", () => void save(SIGN_PREFILL_MOBILE, mobile.value));
+
+  const toggle = freshCheckbox("pg-toggle-allow-optimistic-dialog", getAllowOptimisticDialog());
+  toggle.addEventListener("change", () => {
+    void setAllowOptimisticDialog(toggle.checked).catch((err) => {
       console.error("[pg-settings] failed to persist toggle", err);
       setStatus("Could not save setting. Try again.", "error");
     });
   });
 
+  const back = byId<HTMLButtonElement>("pg-settings-back");
+  back.textContent = t("settingsBack");
   const freshBack = back.cloneNode(true) as HTMLButtonElement;
   back.replaceWith(freshBack);
   freshBack.addEventListener("click", () => {
@@ -46,4 +86,35 @@ function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
+}
+
+// Clone-replace the input so any listeners attached during a previous
+// mountSettingsView call are dropped before we add new ones — the view
+// is re-mountable from the gear button at any time.
+function freshInput(id: string, value: string): HTMLInputElement {
+  const stale = byId<HTMLInputElement>(id);
+  const fresh = stale.cloneNode(true) as HTMLInputElement;
+  fresh.value = value;
+  stale.replaceWith(fresh);
+  return fresh;
+}
+
+function freshCheckbox(id: string, checked: boolean): HTMLInputElement {
+  const stale = byId<HTMLInputElement>(id);
+  const fresh = stale.cloneNode(true) as HTMLInputElement;
+  fresh.checked = checked;
+  stale.replaceWith(fresh);
+  return fresh;
+}
+
+function ddmmyyyyToHtml(ddmmyyyy: string): string {
+  if (!ddmmyyyy) return "";
+  const p = ddmmyyyy.split("-");
+  return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : "";
+}
+
+function htmlToDdmmyyyy(yyyymmdd: string): string {
+  if (!yyyymmdd) return "";
+  const p = yyyymmdd.split("-");
+  return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : "";
 }

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -66,14 +66,15 @@ export function mountSettingsView(returnTo: ViewName): void {
     };
     setSignPrefills(next)
       .then(() => {
+        // Status banner lives outside the view sections so the user sees
+        // "Saved." on whichever view we return to.
         setStatus(t("settingsSaved"));
         setTimeout(() => setStatus(""), 2000);
+        showView(returnTo);
       })
       .catch((err) => {
         console.error("[pg-settings] failed to persist prefills", err);
         setStatus(t("settingsSaveError"), "error");
-      })
-      .finally(() => {
         save.disabled = false;
       });
   });

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -55,12 +55,16 @@ export function mountSettingsView(returnTo: ViewName): void {
     }
   };
 
-  fullname.addEventListener("input", () => void save(SIGN_PREFILL_FULLNAME, fullname.value));
+  // Persist on `change` (blur) rather than `input` (every keystroke).
+  // roamingSettings.saveAsync intermittently fails with code 9019
+  // ("GenericSettingsError") when fired rapidly in succession; debouncing
+  // at the source removes the churn entirely.
+  fullname.addEventListener("change", () => void save(SIGN_PREFILL_FULLNAME, fullname.value));
   dob.addEventListener(
-    "input",
+    "change",
     () => void save(SIGN_PREFILL_DATEOFBIRTH, htmlToDdmmyyyy(dob.value))
   );
-  mobile.addEventListener("input", () => void save(SIGN_PREFILL_MOBILE, mobile.value));
+  mobile.addEventListener("change", () => void save(SIGN_PREFILL_MOBILE, mobile.value));
 
   const toggle = freshCheckbox("pg-toggle-allow-optimistic-dialog", getAllowOptimisticDialog());
   toggle.addEventListener("change", () => {

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -1,0 +1,49 @@
+// Settings view: a single roaming-settings-backed toggle for the
+// "skip the open-a-dialog confirmation" preference, with a Back button
+// that returns to whichever view opened it.
+
+import { getAllowOptimisticDialog, setAllowOptimisticDialog } from "../lib/settings";
+import { t } from "../lib/i18n";
+import { showView, setStatus, ViewName } from "./taskpane";
+
+export function mountSettingsView(returnTo: ViewName): void {
+  const title = byId<HTMLElement>("pg-settings-title");
+  const label = byId<HTMLElement>("pg-settings-optimistic-label");
+  const help = byId<HTMLElement>("pg-settings-optimistic-help");
+  const toggle = byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog");
+  const back = byId<HTMLButtonElement>("pg-settings-back");
+
+  title.textContent = t("settingsTitle");
+  label.textContent = t("settingsAllowOptimisticDialogLabel");
+  help.textContent = t("settingsAllowOptimisticDialogHelp");
+  back.textContent = t("settingsBack");
+
+  toggle.checked = getAllowOptimisticDialog();
+
+  // Replace any listeners from a previous mount by cloning. The settings
+  // view is re-mountable from multiple entry points (compose, read), so
+  // we cannot rely on a single addEventListener call per app lifetime.
+  const freshToggle = toggle.cloneNode(true) as HTMLInputElement;
+  toggle.replaceWith(freshToggle);
+  freshToggle.addEventListener("change", () => {
+    void setAllowOptimisticDialog(freshToggle.checked).catch((err) => {
+      console.error("[pg-settings] failed to persist toggle", err);
+      setStatus("Could not save setting. Try again.", "error");
+    });
+  });
+
+  const freshBack = back.cloneNode(true) as HTMLButtonElement;
+  back.replaceWith(freshBack);
+  freshBack.addEventListener("click", () => {
+    setStatus("");
+    showView(returnTo);
+  });
+
+  showView("settings");
+}
+
+function byId<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Missing element #${id}`);
+  return el as T;
+}

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -423,6 +423,47 @@ body {
   outline-offset: 2px;
 }
 
+/* Selected optional sign attribute — filled chip with × delete. */
+.pg-policy-selected-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 24px;
+  padding: 4px 4px 4px 12px;
+  border: 1px solid var(--pg-accent);
+  border-radius: 999px;
+  background: var(--pg-info-bg);
+  color: var(--pg-accent);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.pg-policy-selected-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.pg-policy-selected-chip-remove:hover {
+  background: var(--pg-accent);
+  color: var(--pg-accent-fg);
+}
+
+.pg-policy-selected-chip-remove:focus-visible {
+  outline: 2px solid var(--pg-accent);
+  outline-offset: 2px;
+}
+
 /* Yivi host - the SDK injects the QR widget here. The official
    @privacybydesign/yivi-css stylesheet (loaded ahead of this file)
    handles the internal layout; we only set the outer container's

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -94,6 +94,40 @@ body {
   display: none;
 }
 
+/* Floating Settings (gear) button, anchored top-right. Visible only
+   from the stable entry views — taskpane.ts toggles [hidden] on
+   transient views (loading/yivi/error/settings itself). */
+.pg-settings-button {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--pg-radius);
+  background: transparent;
+  color: var(--pg-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.pg-settings-button:hover {
+  background: var(--pg-secondary-bg);
+  color: inherit;
+}
+
+.pg-settings-button:focus-visible {
+  outline: 2px solid var(--pg-info-fg);
+  outline-offset: 2px;
+}
+
+.pg-settings-button[hidden] {
+  display: none;
+}
+
 .pg-section-title {
   margin: 0 0 12px;
   font-size: 16px;

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -428,13 +428,22 @@ body {
   outline-offset: 2px;
 }
 
-/* Yivi host - the SDK injects the QR widget here */
+/* Yivi host - the SDK injects the QR widget here. Use a column flex
+   so the SDK's stacked elements (auth tabs, QR, helper links) all
+   sit centered horizontally. */
 
 .pg-yivi-host {
-  min-height: 320px;
+  min-height: 360px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
+}
+
+.pg-yivi-host > * {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Decrypted view */

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -94,38 +94,33 @@ body {
   display: none;
 }
 
-/* Floating Settings (gear) button, anchored top-right. Visible only
-   from the stable entry views — taskpane.ts toggles [hidden] on
-   transient views (loading/yivi/error/settings itself). */
-.pg-settings-button {
-  position: fixed;
-  top: 8px;
-  right: 8px;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--pg-radius);
-  background: transparent;
-  color: var(--pg-muted);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  z-index: 10;
+/* Settings entry: a labeled "⚙ Settings" button pinned at the bottom
+   of the taskpane. Visible only from the stable entry views —
+   taskpane.ts toggles the footer's [hidden] attribute on transient
+   views (loading/yivi/error/settings itself). */
+.pg-footer {
+  padding: 8px 16px;
+  border-top: 1px solid var(--pg-border);
+  background: var(--pg-bg);
+  display: flex;
+  justify-content: center;
 }
 
-.pg-settings-button:hover {
-  background: var(--pg-secondary-bg);
-  color: inherit;
-}
-
-.pg-settings-button:focus-visible {
-  outline: 2px solid var(--pg-info-fg);
-  outline-offset: 2px;
-}
-
-.pg-settings-button[hidden] {
+.pg-footer[hidden] {
   display: none;
+}
+
+.pg-footer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  justify-content: center;
+}
+
+.pg-footer-btn-icon {
+  font-size: 16px;
+  line-height: 1;
 }
 
 .pg-section-title {

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -428,47 +428,13 @@ body {
   outline-offset: 2px;
 }
 
-/* Yivi host - the SDK injects the QR widget here.
-   yivi-web ships no stylesheet, so .yivi-web-header / .yivi-web-content /
-   .yivi-web-centered / .yivi-web-qr-code render as plain block elements
-   unless we style them. Force a column flex layout all the way down so
-   the QR (and helper links / loaders / buttons) end up horizontally
-   centered. */
+/* Yivi host - the SDK injects the QR widget here. The official
+   @privacybydesign/yivi-css stylesheet (loaded ahead of this file)
+   handles the internal layout; we only set the outer container's
+   min-height. */
 
 .pg-yivi-host {
   min-height: 360px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-}
-
-.pg-yivi-host .yivi-web-header,
-.pg-yivi-host .yivi-web-content,
-.pg-yivi-host .yivi-web-centered {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-}
-
-.pg-yivi-host .yivi-web-qr-code {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  max-width: 280px;
-  margin: 0 auto;
-}
-
-.pg-yivi-host .yivi-web-qr-code svg,
-.pg-yivi-host .yivi-web-qr-code img {
-  display: block;
-  width: 100%;
-  max-width: 240px;
-  height: auto;
-  margin: 0 auto;
 }
 
 /* Decrypted view */

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -428,9 +428,12 @@ body {
   outline-offset: 2px;
 }
 
-/* Yivi host - the SDK injects the QR widget here. Use a column flex
-   so the SDK's stacked elements (auth tabs, QR, helper links) all
-   sit centered horizontally. */
+/* Yivi host - the SDK injects the QR widget here.
+   yivi-web ships no stylesheet, so .yivi-web-header / .yivi-web-content /
+   .yivi-web-centered / .yivi-web-qr-code render as plain block elements
+   unless we style them. Force a column flex layout all the way down so
+   the QR (and helper links / loaders / buttons) end up horizontally
+   centered. */
 
 .pg-yivi-host {
   min-height: 360px;
@@ -441,9 +444,31 @@ body {
   width: 100%;
 }
 
-.pg-yivi-host > * {
-  margin-left: auto;
-  margin-right: auto;
+.pg-yivi-host .yivi-web-header,
+.pg-yivi-host .yivi-web-content,
+.pg-yivi-host .yivi-web-centered {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.pg-yivi-host .yivi-web-qr-code {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+.pg-yivi-host .yivi-web-qr-code svg,
+.pg-yivi-host .yivi-web-qr-code img {
+  display: block;
+  width: 100%;
+  max-width: 240px;
+  height: auto;
+  margin: 0 auto;
 }
 
 /* Decrypted view */

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -15,17 +15,6 @@
   <body class="pg-app">
     <div id="pg-status" class="pg-status pg-status-hidden" role="status"></div>
 
-    <button
-      id="pg-open-settings"
-      class="pg-settings-button"
-      type="button"
-      aria-label="PostGuard Settings"
-      title="PostGuard Settings"
-      hidden
-    >
-      <span aria-hidden="true">⚙</span>
-    </button>
-
     <main class="pg-main">
       <!-- Loading view -->
       <section id="view-loading" class="pg-view">
@@ -128,5 +117,12 @@
         </div>
       </section>
     </main>
+
+    <footer class="pg-footer" hidden id="pg-footer">
+      <button id="pg-open-settings" class="pg-btn pg-btn-secondary pg-footer-btn" type="button">
+        <span class="pg-footer-btn-icon" aria-hidden="true">⚙</span>
+        <span id="pg-open-settings-label" class="pg-footer-btn-label"></span>
+      </button>
+    </footer>
   </body>
 </html>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -133,6 +133,7 @@
 
         <div class="pg-button-row pg-button-row-end">
           <button id="pg-settings-back" class="pg-btn pg-btn-secondary" type="button"></button>
+          <button id="pg-settings-save" class="pg-btn pg-btn-primary" type="button"></button>
         </div>
       </section>
     </main>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -35,11 +35,6 @@
 
         <div id="pg-bcc-warning" class="pg-warning" role="alert" hidden></div>
 
-        <div id="pg-sign-section" class="pg-policy-section">
-          <h3 id="pg-sign-title" class="pg-section-title"></h3>
-          <div id="pg-sign-panel"></div>
-        </div>
-
         <div id="pg-manage-section" class="pg-policy-section">
           <h3 id="pg-manage-title" class="pg-section-title"></h3>
           <div id="pg-manage-panel"></div>
@@ -100,6 +95,29 @@
       <!-- Settings view -->
       <section id="view-settings" class="pg-view" hidden>
         <h2 id="pg-settings-title" class="pg-section-title"></h2>
+
+        <h3 id="pg-settings-prefill-title" class="pg-section-title pg-section-subtitle"></h3>
+        <p id="pg-settings-prefill-help" class="pg-subtitle"></p>
+        <div class="pg-policy-attr">
+          <label for="pg-prefill-fullname" id="pg-prefill-fullname-label"></label>
+          <div class="pg-policy-attr-input">
+            <input id="pg-prefill-fullname" type="text" autocomplete="name" />
+          </div>
+        </div>
+        <div class="pg-policy-attr">
+          <label for="pg-prefill-dateofbirth" id="pg-prefill-dateofbirth-label"></label>
+          <div class="pg-policy-attr-input">
+            <input id="pg-prefill-dateofbirth" type="date" />
+          </div>
+        </div>
+        <div class="pg-policy-attr">
+          <label for="pg-prefill-mobile" id="pg-prefill-mobile-label"></label>
+          <div class="pg-policy-attr-input">
+            <input id="pg-prefill-mobile" type="tel" placeholder="+31612345678" autocomplete="tel" />
+          </div>
+        </div>
+
+        <h3 id="pg-settings-advanced-title" class="pg-section-title pg-section-subtitle"></h3>
         <div class="pg-toggle-row">
           <label class="pg-switch">
             <input
@@ -112,6 +130,7 @@
           <span id="pg-settings-optimistic-label" class="pg-toggle-label"></span>
         </div>
         <p id="pg-settings-optimistic-help" class="pg-subtitle"></p>
+
         <div class="pg-button-row pg-button-row-end">
           <button id="pg-settings-back" class="pg-btn pg-btn-secondary" type="button"></button>
         </div>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -14,6 +14,17 @@
   <body class="pg-app">
     <div id="pg-status" class="pg-status pg-status-hidden" role="status"></div>
 
+    <button
+      id="pg-open-settings"
+      class="pg-settings-button"
+      type="button"
+      aria-label="PostGuard Settings"
+      title="PostGuard Settings"
+      hidden
+    >
+      <span aria-hidden="true">⚙</span>
+    </button>
+
     <main class="pg-main">
       <!-- Loading view -->
       <section id="view-loading" class="pg-view">
@@ -94,6 +105,26 @@
       <section id="view-error" class="pg-view" hidden>
         <div class="pg-error" id="pg-error-text"></div>
         <button id="pg-error-retry" class="pg-btn pg-btn-secondary" type="button">Retry</button>
+      </section>
+
+      <!-- Settings view -->
+      <section id="view-settings" class="pg-view" hidden>
+        <h2 id="pg-settings-title" class="pg-section-title"></h2>
+        <div class="pg-toggle-row">
+          <label class="pg-switch">
+            <input
+              type="checkbox"
+              id="pg-toggle-allow-optimistic-dialog"
+              aria-labelledby="pg-settings-optimistic-label"
+            />
+            <span class="pg-switch-track" aria-hidden="true"></span>
+          </label>
+          <span id="pg-settings-optimistic-label" class="pg-toggle-label"></span>
+        </div>
+        <p id="pg-settings-optimistic-help" class="pg-subtitle"></p>
+        <div class="pg-button-row pg-button-row-end">
+          <button id="pg-settings-back" class="pg-btn pg-btn-secondary" type="button"></button>
+        </div>
       </section>
     </main>
   </body>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -9,6 +9,7 @@
       type="text/javascript"
       src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"
     ></script>
+    <link href="yivi.min.css" rel="stylesheet" type="text/css" />
     <link href="taskpane.css" rel="stylesheet" type="text/css" />
   </head>
   <body class="pg-app">

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -4,6 +4,7 @@
 import { isComposeMode } from "../lib/office-helpers";
 import { mountComposeView } from "./compose-view";
 import { mountReadView } from "./read-view";
+import { mountSettingsView } from "./settings-view";
 
 const views = {
   loading: byId("view-loading"),
@@ -14,14 +15,32 @@ const views = {
   decrypted: byId("view-decrypted"),
   yivi: byId("view-yivi"),
   error: byId("view-error"),
+  settings: byId("view-settings"),
 };
 
 export type ViewName = keyof typeof views;
+
+// Views from which the floating gear is visible. Transient views
+// (loading/yivi/error) and the settings view itself stay clean.
+const SETTINGS_ENTRY_VIEWS: ReadonlySet<ViewName> = new Set<ViewName>([
+  "compose",
+  "read_encrypted",
+  "read_was_encrypted",
+  "read_noop",
+  "decrypted",
+]);
+
+let lastSettingsEntryView: ViewName = "compose";
 
 export function showView(name: ViewName): void {
   for (const [k, el] of Object.entries(views)) {
     if (el) el.hidden = k !== name;
   }
+  if (SETTINGS_ENTRY_VIEWS.has(name)) {
+    lastSettingsEntryView = name;
+  }
+  const gear = byId("pg-open-settings");
+  if (gear) gear.hidden = !SETTINGS_ENTRY_VIEWS.has(name);
 }
 
 export function showError(message: string): void {
@@ -55,6 +74,9 @@ Office.onReady((info) => {
 
   const retry = byId("pg-error-retry") as HTMLButtonElement | null;
   if (retry) retry.addEventListener("click", () => bootstrap());
+
+  const gear = byId("pg-open-settings") as HTMLButtonElement | null;
+  if (gear) gear.addEventListener("click", () => mountSettingsView(lastSettingsEntryView));
 
   bootstrap();
 });

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -21,8 +21,8 @@ const views = {
 
 export type ViewName = keyof typeof views;
 
-// Views from which the floating gear is visible. Transient views
-// (loading/yivi/error) and the settings view itself stay clean.
+// Views from which the Settings footer button is visible. Transient
+// views (loading/yivi/error) and the settings view itself stay clean.
 const SETTINGS_ENTRY_VIEWS: ReadonlySet<ViewName> = new Set<ViewName>([
   "compose",
   "read_encrypted",
@@ -40,8 +40,8 @@ export function showView(name: ViewName): void {
   if (SETTINGS_ENTRY_VIEWS.has(name)) {
     lastSettingsEntryView = name;
   }
-  const gear = byId("pg-open-settings");
-  if (gear) gear.hidden = !SETTINGS_ENTRY_VIEWS.has(name);
+  const footer = byId("pg-footer");
+  if (footer) footer.hidden = !SETTINGS_ENTRY_VIEWS.has(name);
 }
 
 export function showError(message: string): void {
@@ -85,8 +85,15 @@ Office.onReady((info) => {
   const noopText = byId("pg-read-noop-text");
   if (noopText) noopText.textContent = t("readNoopMessage");
 
-  const gear = byId("pg-open-settings") as HTMLButtonElement | null;
-  if (gear) gear.addEventListener("click", () => mountSettingsView(lastSettingsEntryView));
+  const settingsLabel = byId("pg-open-settings-label");
+  if (settingsLabel) settingsLabel.textContent = t("settingsOpen");
+
+  const settingsBtn = byId("pg-open-settings") as HTMLButtonElement | null;
+  if (settingsBtn) {
+    settingsBtn.setAttribute("aria-label", t("settingsOpen"));
+    settingsBtn.title = t("settingsOpen");
+    settingsBtn.addEventListener("click", () => mountSettingsView(lastSettingsEntryView));
+  }
 
   bootstrap();
 });

--- a/src/yivi-dialog/yivi-dialog.html
+++ b/src/yivi-dialog/yivi-dialog.html
@@ -9,6 +9,7 @@
       type="text/javascript"
       src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"
     ></script>
+    <link href="yivi.min.css" rel="stylesheet" type="text/css" />
     <link href="../taskpane/taskpane.css" rel="stylesheet" type="text/css" />
   </head>
   <body class="pg-app">

--- a/src/yivi-dialog/yivi-dialog.html
+++ b/src/yivi-dialog/yivi-dialog.html
@@ -17,9 +17,11 @@
         <h2 id="pg-dlg-title" class="pg-section-title">PostGuard</h2>
         <p id="pg-dlg-subtitle" class="pg-subtitle">Preparing encryption…</p>
         <aside id="pg-dlg-safari-tip" class="pg-info" hidden>
-          Safari blocks this window by default. Allow popups for this
-          site in Safari → Settings → Websites → Pop-ups → Allow to
-          skip the confirmation on every send.
+          Safari blocks this window by default. To skip the
+          "PostGuard wants to open a dialog" prompt on every send,
+          allow pop-ups for this site (Safari → Settings → Websites
+          → Pop-ups → Allow) and then enable "Skip the open-a-dialog
+          confirmation" in the PostGuard taskpane's Settings.
         </aside>
         <div id="yivi-web-form" class="pg-yivi-host"></div>
         <div id="pg-dlg-error" class="pg-error" role="alert" hidden></div>

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -30,6 +30,10 @@ interface EncryptRequest {
   subject: string;
   htmlBody: string;
   attachments: AttachmentPayload[];
+  // Optional sign attributes the user selected in the compose taskpane.
+  // Forwarded as { t, optional: true } so the Yivi app prompts for them
+  // (the user can still skip any single one).
+  signAttributes?: { t: string; optional?: boolean }[];
 }
 
 interface EncryptResult {
@@ -130,10 +134,15 @@ async function runEncryption(req: EncryptRequest): Promise<EncryptResult> {
     (pg as never as { recipient: { email: (e: string) => unknown } }).recipient.email(email)
   );
 
+  const signAttrs = (req.signAttributes ?? []).map((a) => ({ t: a.t, optional: true }));
+  log(`sign attributes: ${signAttrs.map((a) => a.t).join(", ") || "<none>"}`);
+
   const sealed = pg.encrypt({
     sign: pg.sign.yivi({
       element: "#yivi-web-form",
       senderEmail: req.senderEmail,
+      includeSender: true,
+      attributes: signAttrs.length ? signAttrs : undefined,
     } as never),
     recipients,
     data: mime,

--- a/src/yivi-dialog/yivi-dialog.ts
+++ b/src/yivi-dialog/yivi-dialog.ts
@@ -30,10 +30,11 @@ interface EncryptRequest {
   subject: string;
   htmlBody: string;
   attachments: AttachmentPayload[];
-  // Optional sign attributes the user selected in the compose taskpane.
-  // Forwarded as { t, optional: true } so the Yivi app prompts for them
-  // (the user can still skip any single one).
-  signAttributes?: { t: string; optional?: boolean }[];
+  // Sender sign attributes built from the user's Settings prefills. Each
+  // entry is either { t, v } (mandatory disclosure match — Yivi must
+  // present a credential whose attribute equals `v`) or { t, optional: true }
+  // (the Yivi app prompts, the user can skip).
+  signAttributes?: { t: string; v?: string; optional?: boolean }[];
 }
 
 interface EncryptResult {
@@ -134,8 +135,21 @@ async function runEncryption(req: EncryptRequest): Promise<EncryptResult> {
     (pg as never as { recipient: { email: (e: string) => unknown } }).recipient.email(email)
   );
 
-  const signAttrs = (req.signAttributes ?? []).map((a) => ({ t: a.t, optional: true }));
-  log(`sign attributes: ${signAttrs.map((a) => a.t).join(", ") || "<none>"}`);
+  // Forward the launchevent-built list verbatim — each entry is already
+  // either { t, v } (mandatory match, from a Settings prefill) or
+  // { t, optional: true } (no prefill). The previous code stripped `v`
+  // and forced every entry back to optional, defeating the prefill flow.
+  const signAttrs = (req.signAttributes ?? []).map((a) => ({
+    t: a.t,
+    ...(a.v !== undefined ? { v: a.v } : {}),
+    ...(a.optional ? { optional: true } : {}),
+  }));
+  log(
+    `sign attributes: ${
+      signAttrs.map((a) => `${a.t}${a.v ? `=${a.v}` : a.optional ? ":optional" : ""}`).join(", ") ||
+      "<none>"
+    }`
+  );
 
   const sealed = pg.encrypt({
     sign: pg.sign.yivi({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,18 @@ module.exports = async (env, options) => {
         {
           test: /\.html$/,
           exclude: /node_modules/,
-          use: "html-loader",
+          use: {
+            loader: "html-loader",
+            options: {
+              // yivi.min.css is copied into dist/ by CopyWebpackPlugin
+              // below — leave the <link href> untouched so the browser
+              // resolves it at runtime from the same directory as the
+              // HTML page.
+              sources: {
+                urlFilter: (_attribute, value) => !/(^|\/)yivi\.min\.css$/.test(value),
+              },
+            },
+          },
         },
         {
           test: /\.(png|jpg|jpeg|gif|ico|svg)$/,
@@ -105,6 +116,10 @@ module.exports = async (env, options) => {
       new CopyWebpackPlugin({
         patterns: [
           { from: "assets/*", to: "assets/[name][ext][query]" },
+          {
+            from: "node_modules/@privacybydesign/yivi-css/dist/yivi.min.css",
+            to: "yivi.min.css",
+          },
           {
             from: "manifest*.xml",
             to: "[name][ext]",


### PR DESCRIPTION
## Summary
- Default `displayDialogAsync` to `promptBeforeOpen: true` in `runEncryptDialog`, so the user's "Allow" click is itself the gesture that opens the Yivi popup — reliable on every host, including Safari without site-level popup permission.
- New Settings view in the taskpane (gear icon, top-right) with a single toggle backed by the `pg.allowOptimisticDialog` roaming setting. When enabled, the launchevent attempts the optimistic open and falls back to one prompted retry if blocked.
- Update the Safari hint inside the Yivi dialog to point at the new Settings toggle.
- Add an entry to `docs/outlook-quirks.md` explaining the new default.

Closes #48.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — passes (only pre-existing entrypoint-size warnings)
- [x] `npm run validate` — manifest valid
- [x] **Default behaviour (setting unset):** compose + Send on Safari → Office "PostGuard wants to open a dialog → Allow" prompt appears, Yivi dialog opens, no security error.
- [x] **Opt-in path:** taskpane → gear → flip *Skip the "open a dialog" confirmation* → Send on Chrome/Edge/Firefox → dialog opens with no Office prompt.
- [x] **Opt-in fallback:** with the toggle on but Safari pop-ups not yet allowed → log shows `optimistic attempt failed … retrying with promptBeforeOpen=true` and the dialog still opens after Allow.
- [x] **Roaming persistence:** toggle on, close + reopen Outlook → still on.
- [x] **Read-mode regression:** open an encrypted message, hit gear → Settings → Back → returns to `view-read-encrypted`/`view-decrypted` without losing state.