### PR TITLE
fix(compose): narrow attr.v before extraAttribute call

### DIFF
--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -503,9 +503,13 @@ function buildPgRecipients(pg: PostGuard): unknown[] {
     const policy = state.policy[email];
     if (policy) {
       for (const attr of policy) {
-        if (attr.t !== EMAIL_ATTRIBUTE_TYPE) {
-          builder.extraAttribute(attr.t, attr.v.toLowerCase());
-        }
+        if (attr.t === EMAIL_ATTRIBUTE_TYPE) continue;
+        // Manage Access entries always carry a value (the policy editor
+        // filters out empty rows before storing them on state.policy),
+        // but AttributeRequest.v is typed as optional now that sign-side
+        // entries omit it — narrow defensively for the typechecker.
+        if (!attr.v) continue;
+        builder.extraAttribute(attr.t, attr.v.toLowerCase());
       }
     }
     return builder;


### PR DESCRIPTION
## Summary
- `AttributeRequest.v` was made optional in #63 to support sign-side entries shaped as `{ t, optional: true }`.
- The Manage Access loop in `buildPgRecipients` still calls `.toLowerCase()` on `attr.v` directly, which `tsc --noEmit` flags: `src/taskpane/compose-view.ts(507,42): error TS18048: 'attr.v' is possibly 'undefined'`.
- Skip the entry when `v` is missing or empty. The policy editor already filters empty rows out of `state.policy` before this path runs, so this narrows the type for the compiler without changing runtime behaviour.

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [ ] CI typecheck on this PR is green