### PR TITLE
Default encryption off + global toggle + banner + fail-closed send

### DIFF
--- a/docs/outlook-quirks.md
+++ b/docs/outlook-quirks.md
@@ -226,6 +226,16 @@ base64 ciphertext block) the server-side commit can take long enough to look
 like a hang. Either trim the body before setAsync, or call `saveAsync` after
 to surface the wait inside the taskpane's "Saving…" UI rather than at Send.
 
+### `notificationMessages.replaceAsync` silently no-ops on the same key
+
+In new Outlook compose mode, calling `replaceAsync(key, details)` on an
+existing persistent notification reports `Succeeded` but the rendered
+banner text doesn't change — the user keeps seeing the old message.
+`removeAsync(key)` followed by `replaceAsync(key, …)` (or `addAsync`)
+forces a re-paint. We hit this when swapping the "PostGuard is on"
+banner to "PostGuard is off" as the user toggles encryption in the
+taskpane.
+
 ---
 
 ## Display & rendering

--- a/manifest.xml
+++ b/manifest.xml
@@ -186,6 +186,7 @@
             </ExtensionPoint>
             <ExtensionPoint xsi:type="LaunchEvent">
               <LaunchEvents>
+                <LaunchEvent Type="OnNewMessageCompose" FunctionName="onNewMessageComposeHandler"/>
                 <LaunchEvent Type="OnMessageSend" FunctionName="onMessageSendHandler" SendMode="SoftBlock"/>
               </LaunchEvents>
               <SourceLocation resid="WebViewRuntime.Url"/>

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -28,6 +28,12 @@ import { t } from "../lib/i18n";
 
 const ENCRYPTION_STATUS_NOTIFICATION_KEY = "postguard-encryption-status";
 
+// Per-draft "is this email going to be encrypted on send" flag. Written
+// by the taskpane's compose toggle and seeded from the mailbox-wide
+// default by OnNewMessageCompose, so by the time OnMessageSend fires
+// the header reflects the user's explicit intent for *this* message.
+// The OnMessageSend handler reads only this header — never the global
+// setting — so a PostGuard outage can never block an unencrypted send.
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
 const HEADER_POSTGUARD = "x-postguard";
@@ -505,127 +511,151 @@ async function encryptAndApply(
 }
 
 function onMessageSendHandler(event: Office.AddinCommands.Event): void {
-  log("onMessageSendHandler invoked");
-  const cancelTimeout = allowAfterTimeout(event);
-
-  const item = Office.context.mailbox.item as Office.MessageCompose;
-  if (!item) {
-    log("no mailbox item; allowing");
-    cancelTimeout();
-    event.completed({ allowEvent: true });
-    return;
-  }
-
-  item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS], (hdrRes) => {
-    log(`internetHeaders.getAsync status=${hdrRes.status}`);
-    if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
-      cancelTimeout();
+  // Outer guard: any unexpected failure in this handler must NOT block
+  // the send. If PostGuard is off (or anything goes wrong reading state),
+  // we release the send immediately so a broken add-in can never stop
+  // an unencrypted email from going out.
+  let released = false;
+  const releaseSend = (reason: string): void => {
+    if (released) return;
+    released = true;
+    log(`releasing send: ${reason}`);
+    try {
       event.completed({ allowEvent: true });
+    } catch (e) {
+      log(`event.completed threw on release: ${String(e)}`);
+    }
+  };
+
+  try {
+    log("onMessageSendHandler invoked");
+
+    const item = Office.context.mailbox.item as Office.MessageCompose | undefined;
+    if (!item || !item.internetHeaders) {
+      releaseSend("no compose item / no internetHeaders");
       return;
     }
 
-    // Per-draft header overrides the mailbox-wide default. "true"/"false"
-    // both mean the user toggled this specific draft explicitly; only when
-    // the header is absent do we fall back to the global setting (which
-    // defaults to off — see settings.ts).
-    const headerVal = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
-    let encryptRequested: boolean;
-    if (headerVal === "true") {
-      encryptRequested = true;
-    } else if (headerVal === "false") {
-      encryptRequested = false;
-    } else {
-      encryptRequested = getEncryptionEnabled();
-    }
-    log(`encryptRequested=${encryptRequested} (header=${headerVal ?? "<absent>"})`);
-    if (!encryptRequested) {
-      cancelTimeout();
-      event.completed({ allowEvent: true });
-      return;
-    }
+    // Single source of truth at send time: the per-draft header. The
+    // header is seeded from the mailbox-wide default by
+    // OnNewMessageCompose and updated by the compose toggle. We only
+    // run the encryption path when the header says "true" — anything
+    // else (false, absent, read failure) releases the send.
+    item.internetHeaders.getAsync(
+      [HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS],
+      (hdrRes) => {
+        if (released) return;
 
-    const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
-
-    item.getAttachmentsAsync(async (attRes) => {
-      log(`getAttachmentsAsync status=${attRes.status}`);
-      const attachments = attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
-      const alreadyEncrypted = attachments.some(
-        (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
-      );
-      log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
-
-      const [to, cc] = await Promise.all([
-        getRecipientsAsync(item.to),
-        getRecipientsAsync(item.cc),
-      ]);
-
-      if (!alreadyEncrypted) {
-        if (to.length + cc.length === 0) {
-          cancelTimeout();
-          block(event, "Add at least one recipient before sending.");
+        if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
+          releaseSend(`header read failed (status=${hdrRes.status})`);
           return;
         }
 
-        // Outlook for Mac (native WKWebView) rejects displayDialogAsync
-        // from the launchevent runtime with E_FAIL regardless of options
-        // or sizing. Tracked upstream at office-js#6677; related stale
-        // reports are #3138, #3085, and #5681. Until Microsoft restores
-        // working dialog support, deflect Mac users to the manual
-        // taskpane "Encrypt & Send" button (which uses the dialog API
-        // from the taskpane runtime, where it works). Note: this only
-        // fires when the message is *not* already encrypted — once the
-        // user has clicked Encrypt & Send in the taskpane and we see
-        // the postguard.encrypted attachment, we fall through to the
-        // standard allow-send path. Remove this branch when 6677 ships.
-        if (Office.context.platform === Office.PlatformType.Mac) {
-          log("Outlook for Mac detected; deferring to taskpane flow");
-          cancelTimeout();
-          block(event, MAC_NOT_SUPPORTED_MESSAGE);
+        const encryptHeader = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
+        if (encryptHeader !== "true") {
+          releaseSend(`x-pg-encrypt-on-send=${encryptHeader ?? "<absent>"}`);
           return;
         }
 
-        try {
-          await encryptAndApply(event, item, to, cc, attachments);
+        // Header says "true" — proceed with the (potentially slow)
+        // encryption flow. Arm the fallback timer only now, so the
+        // off-path never pays for it.
+        const cancelTimeout = allowAfterTimeout(event);
+        const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
+
+        item.getAttachmentsAsync(async (attRes) => {
+          log(`getAttachmentsAsync status=${attRes.status}`);
+          const attachments =
+            attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
+          const alreadyEncrypted = attachments.some(
+            (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+          );
+          log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
+
+          const [to, cc] = await Promise.all([
+            getRecipientsAsync(item.to),
+            getRecipientsAsync(item.cc),
+          ]);
+
+          if (!alreadyEncrypted) {
+            if (to.length + cc.length === 0) {
+              cancelTimeout();
+              block(event, "Add at least one recipient before sending.");
+              return;
+            }
+
+            // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+            // from the launchevent runtime with E_FAIL regardless of options
+            // or sizing. Tracked upstream at office-js#6677; related stale
+            // reports are #3138, #3085, and #5681. Until Microsoft restores
+            // working dialog support, deflect Mac users to the manual
+            // taskpane "Encrypt & Send" button (which uses the dialog API
+            // from the taskpane runtime, where it works). Note: this only
+            // fires when the message is *not* already encrypted — once the
+            // user has clicked Encrypt & Send in the taskpane and we see
+            // the postguard.encrypted attachment, we fall through to the
+            // standard allow-send path. Remove this branch when 6677 ships.
+            if (Office.context.platform === Office.PlatformType.Mac) {
+              log("Outlook for Mac detected; deferring to taskpane flow");
+              cancelTimeout();
+              block(event, MAC_NOT_SUPPORTED_MESSAGE);
+              return;
+            }
+
+            try {
+              await encryptAndApply(event, item, to, cc, attachments);
+              cancelTimeout();
+              event.completed({ allowEvent: true });
+            } catch (e) {
+              cancelTimeout();
+              block(event, `Encryption failed: ${stringifyError(e)}`);
+            }
+            return;
+          }
+
+          // Verify the encryption matches the message's current To+Cc list.
+          const currentKey = recipientsKey([...to, ...cc]);
+          const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
+          log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+
           cancelTimeout();
+          if (stale) {
+            block(event, STALE_ENCRYPTION_MESSAGE);
+            return;
+          }
           event.completed({ allowEvent: true });
-        } catch (e) {
-          cancelTimeout();
-          block(event, `Encryption failed: ${stringifyError(e)}`);
-        }
-        return;
+        });
       }
-
-      // Verify the encryption matches the message's current To+Cc list.
-      const currentKey = recipientsKey([...to, ...cc]);
-      const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
-      log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
-
-      cancelTimeout();
-      if (stale) {
-        block(event, STALE_ENCRYPTION_MESSAGE);
-        return;
-      }
-      event.completed({ allowEvent: true });
-    });
-  });
+    );
+  } catch (e) {
+    releaseSend(`unexpected error in handler: ${stringifyError(e)}`);
+  }
 }
 
 // OnNewMessageCompose handler. Fires when the user opens a new message,
 // reply, or forward — independent of whether the user has clicked the
-// PostGuard ribbon button. We use it to set the "PostGuard is on/off"
-// notification banner at compose-open time so the user always sees
-// whether the next send will be encrypted, before the taskpane is open.
-//
-// Decision order matches OnMessageSend so the banner and the actual
-// behavior never disagree: per-draft header wins, otherwise fall back
-// to the mailbox-wide setting (default off).
+// PostGuard ribbon button. Two jobs:
+//   1. Seed the per-draft x-pg-encrypt-on-send header from the
+//      mailbox-wide default if it isn't already set. This makes the
+//      header the single source of truth for the OnMessageSend handler
+//      while still letting the user pick a default in Settings.
+//   2. Set the persistent in-message "PostGuard is on/off" banner so
+//      the user always sees the current state of this specific draft,
+//      even before opening the taskpane.
 function onNewMessageComposeHandler(event: Office.AddinCommands.Event): void {
   log("onNewMessageComposeHandler invoked");
   const item = Office.context.mailbox.item as Office.MessageCompose | undefined;
-  if (!item || !item.notificationMessages) {
-    log("no compose item or notificationMessages; completing");
+  if (!item || !item.notificationMessages || !item.internetHeaders) {
+    log("no compose item / notificationMessages / internetHeaders; completing");
     event.completed();
     return;
+  }
+
+  let globalDefault = false;
+  try {
+    globalDefault = getEncryptionEnabled();
+  } catch (e) {
+    log(`failed to read encryption setting; assuming off: ${stringifyError(e)}`);
   }
 
   const applyBanner = (encryptOn: boolean): void => {
@@ -654,15 +684,35 @@ function onNewMessageComposeHandler(event: Office.AddinCommands.Event): void {
 
   item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND], (hdrRes) => {
     let encryptOn: boolean;
+    let needsSeed = false;
     if (hdrRes.status === Office.AsyncResultStatus.Succeeded) {
       const v = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
-      if (v === "true") encryptOn = true;
-      else if (v === "false") encryptOn = false;
-      else encryptOn = getEncryptionEnabled();
+      if (v === "true") {
+        encryptOn = true;
+      } else if (v === "false") {
+        encryptOn = false;
+      } else {
+        encryptOn = globalDefault;
+        needsSeed = true;
+      }
     } else {
-      encryptOn = getEncryptionEnabled();
+      // Header read failed — don't write anything, just paint the
+      // banner from the global default. The toggle in the taskpane
+      // can still write the header explicitly later.
+      encryptOn = globalDefault;
     }
-    applyBanner(encryptOn);
+    log(`encryptOn=${encryptOn} (header=${hdrRes.value?.[HEADER_ENCRYPT_ON_SEND] ?? "<absent>"})`);
+
+    if (!needsSeed) {
+      applyBanner(encryptOn);
+      return;
+    }
+    // Seed the header so OnMessageSend has a definite per-draft answer
+    // even if the user never opens the taskpane. Best-effort: if the
+    // write fails we still show the banner so the user sees the state.
+    item.internetHeaders.setAsync({ [HEADER_ENCRYPT_ON_SEND]: encryptOn ? "true" : "false" }, () => {
+      applyBanner(encryptOn);
+    });
   });
 }
 

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -84,11 +84,7 @@ function log(msg: string): void {
 //
 // 4½ min: Outlook's Smart Alerts hard-cap is 5 min, so we stay just
 // under. The user has that long to find their phone and scan the QR.
-function blockAfterTimeout(
-  event: Office.AddinCommands.Event,
-  onFire: () => void,
-  ms = 270000
-): () => void {
+function blockAfterTimeout(onFire: () => void, ms = 270000): () => void {
   const timer = setTimeout(() => {
     log(`fallback timeout (${ms}ms) reached; blocking the send`);
     onFire();
@@ -602,7 +598,7 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
           // From this point on, the user has explicitly asked for this
           // message to be encrypted. Any error must block the send.
           committedToEncrypt = true;
-          const cancelTimeout = blockAfterTimeout(event, () =>
+          const cancelTimeout = blockAfterTimeout(() =>
             blockSend(
               "PostGuard encryption did not finish in time. The message was NOT sent. " +
                 "Try again, or turn PostGuard off in the taskpane to send this message unencrypted."
@@ -737,48 +733,63 @@ function onNewMessageComposeHandler(event: Office.AddinCommands.Event): void {
     // Remove first, then add: replaceAsync silently no-ops on the same
     // key in new Outlook compose mode (see docs/outlook-quirks.md).
     item.notificationMessages.removeAsync(ENCRYPTION_STATUS_NOTIFICATION_KEY, () => {
-      item.notificationMessages.replaceAsync(
-        ENCRYPTION_STATUS_NOTIFICATION_KEY,
-        details,
-        () => {
-          log(`banner set: encryptOn=${encryptOn}`);
-          event.completed();
-        }
-      );
+      item.notificationMessages.replaceAsync(ENCRYPTION_STATUS_NOTIFICATION_KEY, details, () => {
+        log(`banner set: encryptOn=${encryptOn}`);
+        event.completed();
+      });
     });
   };
 
   item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND], (hdrRes) => {
-    let encryptOn: boolean;
-    let needsSeed = false;
+    let desired: boolean;
+    let needsSeed: boolean;
     if (hdrRes.status === Office.AsyncResultStatus.Succeeded) {
       const v = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
       if (v === "true") {
-        encryptOn = true;
+        desired = true;
+        needsSeed = false;
       } else if (v === "false") {
-        encryptOn = false;
+        desired = false;
+        needsSeed = false;
       } else {
-        encryptOn = globalDefault;
+        desired = globalDefault;
         needsSeed = true;
       }
     } else {
-      // Header read failed — don't write anything, just paint the
-      // banner from the global default. The toggle in the taskpane
-      // can still write the header explicitly later.
-      encryptOn = globalDefault;
+      // Header read failed. We have no way to know whether a prior
+      // value already exists, so we still attempt to seed: if the write
+      // succeeds the banner and OnMessageSend agree on the new value;
+      // if it fails, we MUST paint "off" — anything else would be
+      // lying to the user, because OnMessageSend reads only the header
+      // and an unwritten/unreadable header releases the send in
+      // cleartext.
+      desired = globalDefault;
+      needsSeed = true;
     }
-    log(`encryptOn=${encryptOn} (header=${hdrRes.value?.[HEADER_ENCRYPT_ON_SEND] ?? "<absent>"})`);
+    log(
+      `desired=${desired} needsSeed=${needsSeed} ` +
+        `header=${hdrRes.value?.[HEADER_ENCRYPT_ON_SEND] ?? "<absent>"} ` +
+        `getStatus=${hdrRes.status}`
+    );
 
     if (!needsSeed) {
-      applyBanner(encryptOn);
+      applyBanner(desired);
       return;
     }
     // Seed the header so OnMessageSend has a definite per-draft answer
-    // even if the user never opens the taskpane. Best-effort: if the
-    // write fails we still show the banner so the user sees the state.
-    item.internetHeaders.setAsync({ [HEADER_ENCRYPT_ON_SEND]: encryptOn ? "true" : "false" }, () => {
-      applyBanner(encryptOn);
-    });
+    // even if the user never opens the taskpane. If the write fails,
+    // paint "off" so the banner cannot lie about what will happen on
+    // Send.
+    item.internetHeaders.setAsync(
+      { [HEADER_ENCRYPT_ON_SEND]: desired ? "true" : "false" },
+      (setRes) => {
+        const effective = setRes.status === Office.AsyncResultStatus.Succeeded ? desired : false;
+        if (effective !== desired) {
+          log(`header seed failed (status=${setRes.status}); painting banner as off`);
+        }
+        applyBanner(effective);
+      }
+    );
   });
 }
 

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -24,6 +24,9 @@ import {
   getEncryptionEnabled,
 } from "../lib/settings";
 import { stringifyError } from "../lib/stringify-error";
+import { t } from "../lib/i18n";
+
+const ENCRYPTION_STATUS_NOTIFICATION_KEY = "postguard-encryption-status";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 const HEADER_ENCRYPTED_RECIPIENTS = "x-pg-encrypted-recipients";
@@ -607,9 +610,66 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
   });
 }
 
+// OnNewMessageCompose handler. Fires when the user opens a new message,
+// reply, or forward — independent of whether the user has clicked the
+// PostGuard ribbon button. We use it to set the "PostGuard is on/off"
+// notification banner at compose-open time so the user always sees
+// whether the next send will be encrypted, before the taskpane is open.
+//
+// Decision order matches OnMessageSend so the banner and the actual
+// behavior never disagree: per-draft header wins, otherwise fall back
+// to the mailbox-wide setting (default off).
+function onNewMessageComposeHandler(event: Office.AddinCommands.Event): void {
+  log("onNewMessageComposeHandler invoked");
+  const item = Office.context.mailbox.item as Office.MessageCompose | undefined;
+  if (!item || !item.notificationMessages) {
+    log("no compose item or notificationMessages; completing");
+    event.completed();
+    return;
+  }
+
+  const applyBanner = (encryptOn: boolean): void => {
+    const messageText = encryptOn
+      ? t("composeEncryptionOnBanner")
+      : t("composeEncryptionOffBanner");
+    const details: Office.NotificationMessageDetails = {
+      type: Office.MailboxEnums.ItemNotificationMessageType.InformationalMessage,
+      message: messageText.slice(0, 150),
+      icon: "Icon.16x16",
+      persistent: true,
+    };
+    // Remove first, then add: replaceAsync silently no-ops on the same
+    // key in new Outlook compose mode (see docs/outlook-quirks.md).
+    item.notificationMessages.removeAsync(ENCRYPTION_STATUS_NOTIFICATION_KEY, () => {
+      item.notificationMessages.replaceAsync(
+        ENCRYPTION_STATUS_NOTIFICATION_KEY,
+        details,
+        () => {
+          log(`banner set: encryptOn=${encryptOn}`);
+          event.completed();
+        }
+      );
+    });
+  };
+
+  item.internetHeaders.getAsync([HEADER_ENCRYPT_ON_SEND], (hdrRes) => {
+    let encryptOn: boolean;
+    if (hdrRes.status === Office.AsyncResultStatus.Succeeded) {
+      const v = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
+      if (v === "true") encryptOn = true;
+      else if (v === "false") encryptOn = false;
+      else encryptOn = getEncryptionEnabled();
+    } else {
+      encryptOn = getEncryptionEnabled();
+    }
+    applyBanner(encryptOn);
+  });
+}
+
 log("script loaded");
 Office.onReady((info) => {
   log(`Office.onReady fired; host=${info?.host} platform=${info?.platform}`);
   Office.actions.associate("onMessageSendHandler", onMessageSendHandler);
-  log("handler associated");
+  Office.actions.associate("onNewMessageComposeHandler", onNewMessageComposeHandler);
+  log("handlers associated");
 });

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -18,7 +18,11 @@
 
 import { ChunkAssembler, chunkPayload, isChunkMessage, ChunkMessage } from "../lib/dialog-chunk";
 import { ADDIN_PUBLIC_URL } from "../lib/pkg-client";
-import { buildSignAttributes, getAllowOptimisticDialog } from "../lib/settings";
+import {
+  buildSignAttributes,
+  getAllowOptimisticDialog,
+  getEncryptionEnabled,
+} from "../lib/settings";
 import { stringifyError } from "../lib/stringify-error";
 
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
@@ -517,8 +521,20 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
       return;
     }
 
-    const encryptRequested = hdrRes.value[HEADER_ENCRYPT_ON_SEND] === "true";
-    log(`encryptRequested=${encryptRequested}`);
+    // Per-draft header overrides the mailbox-wide default. "true"/"false"
+    // both mean the user toggled this specific draft explicitly; only when
+    // the header is absent do we fall back to the global setting (which
+    // defaults to off — see settings.ts).
+    const headerVal = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
+    let encryptRequested: boolean;
+    if (headerVal === "true") {
+      encryptRequested = true;
+    } else if (headerVal === "false") {
+      encryptRequested = false;
+    } else {
+      encryptRequested = getEncryptionEnabled();
+    }
+    log(`encryptRequested=${encryptRequested} (header=${headerVal ?? "<absent>"})`);
     if (!encryptRequested) {
       cancelTimeout();
       event.completed({ allowEvent: true });

--- a/src/launchevent/launchevent.ts
+++ b/src/launchevent/launchevent.ts
@@ -75,16 +75,23 @@ function log(msg: string): void {
   console.log(`[pg-launchevent] ${msg}`);
 }
 
-function allowAfterTimeout(event: Office.AddinCommands.Event, ms = 270000): () => void {
-  // 4½ min — gives the user time to find their phone and scan the QR.
-  // Outlook's own Smart Alerts hard-cap is 5 min so we stay just under.
+// Encryption-path watchdog. Once the user opts into encrypting this
+// message (x-pg-encrypt-on-send=true), we must never release the send
+// in cleartext — silently sending an unencrypted email that the user
+// asked to be encrypted is the worst possible failure mode. So if the
+// encryption flow doesn't complete in time, block the send with a
+// clear error and let the user retry.
+//
+// 4½ min: Outlook's Smart Alerts hard-cap is 5 min, so we stay just
+// under. The user has that long to find their phone and scan the QR.
+function blockAfterTimeout(
+  event: Office.AddinCommands.Event,
+  onFire: () => void,
+  ms = 270000
+): () => void {
   const timer = setTimeout(() => {
-    log(`fallback timeout (${ms}ms) reached; allowing the send`);
-    try {
-      event.completed({ allowEvent: true });
-    } catch (e) {
-      log(`fallback event.completed threw: ${String(e)}`);
-    }
+    log(`fallback timeout (${ms}ms) reached; blocking the send`);
+    onFire();
   }, ms);
   return () => clearTimeout(timer);
 }
@@ -511,19 +518,51 @@ async function encryptAndApply(
 }
 
 function onMessageSendHandler(event: Office.AddinCommands.Event): void {
-  // Outer guard: any unexpected failure in this handler must NOT block
-  // the send. If PostGuard is off (or anything goes wrong reading state),
-  // we release the send immediately so a broken add-in can never stop
-  // an unencrypted email from going out.
-  let released = false;
+  // Two completion modes:
+  //   - release  → event.completed({ allowEvent: true }).  Email goes
+  //                out as-is (no PostGuard involvement). Use for the
+  //                "off" or "indeterminate" paths so a broken add-in
+  //                can never stop an unencrypted send from happening.
+  //   - blockSend → event.completed({ allowEvent: false, errorMessage }).
+  //                Outlook shows a Smart Alert and refuses the send.
+  //                Use whenever we have committed to encrypting and
+  //                something then went wrong — silently sending a
+  //                "supposed to be encrypted" email in plaintext is
+  //                the failure mode we never accept.
+  //
+  // `committedToEncrypt` flips to true the instant we confirm the
+  // header is "true", so any error after that point routes to
+  // blockSend instead of releaseSend.
+  let settled = false;
+  let committedToEncrypt = false;
+
   const releaseSend = (reason: string): void => {
-    if (released) return;
-    released = true;
+    if (settled) return;
+    settled = true;
     log(`releasing send: ${reason}`);
     try {
       event.completed({ allowEvent: true });
     } catch (e) {
       log(`event.completed threw on release: ${String(e)}`);
+    }
+  };
+
+  const blockSend = (errorMessage: string): void => {
+    if (settled) return;
+    settled = true;
+    log(`blocking send: ${errorMessage}`);
+    try {
+      block(event, errorMessage);
+    } catch (e) {
+      log(`block threw: ${String(e)}`);
+    }
+  };
+
+  const onFailure = (reason: string): void => {
+    if (committedToEncrypt) {
+      blockSend(`PostGuard encryption failed: ${reason}`);
+    } else {
+      releaseSend(reason);
     }
   };
 
@@ -540,95 +579,122 @@ function onMessageSendHandler(event: Office.AddinCommands.Event): void {
     // header is seeded from the mailbox-wide default by
     // OnNewMessageCompose and updated by the compose toggle. We only
     // run the encryption path when the header says "true" — anything
-    // else (false, absent, read failure) releases the send.
+    // else (false, absent, read failure) releases the send so a
+    // PostGuard outage cannot block an unencrypted email from going
+    // out. Once we *have* seen "true", encryption is non-negotiable.
     item.internetHeaders.getAsync(
       [HEADER_ENCRYPT_ON_SEND, HEADER_ENCRYPTED_RECIPIENTS],
       (hdrRes) => {
-        if (released) return;
+        if (settled) return;
 
-        if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
-          releaseSend(`header read failed (status=${hdrRes.status})`);
-          return;
-        }
+        try {
+          if (hdrRes.status !== Office.AsyncResultStatus.Succeeded) {
+            releaseSend(`header read failed (status=${hdrRes.status})`);
+            return;
+          }
 
-        const encryptHeader = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
-        if (encryptHeader !== "true") {
-          releaseSend(`x-pg-encrypt-on-send=${encryptHeader ?? "<absent>"}`);
-          return;
-        }
+          const encryptHeader = hdrRes.value[HEADER_ENCRYPT_ON_SEND];
+          if (encryptHeader !== "true") {
+            releaseSend(`x-pg-encrypt-on-send=${encryptHeader ?? "<absent>"}`);
+            return;
+          }
 
-        // Header says "true" — proceed with the (potentially slow)
-        // encryption flow. Arm the fallback timer only now, so the
-        // off-path never pays for it.
-        const cancelTimeout = allowAfterTimeout(event);
-        const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
-
-        item.getAttachmentsAsync(async (attRes) => {
-          log(`getAttachmentsAsync status=${attRes.status}`);
-          const attachments =
-            attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
-          const alreadyEncrypted = attachments.some(
-            (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+          // From this point on, the user has explicitly asked for this
+          // message to be encrypted. Any error must block the send.
+          committedToEncrypt = true;
+          const cancelTimeout = blockAfterTimeout(event, () =>
+            blockSend(
+              "PostGuard encryption did not finish in time. The message was NOT sent. " +
+                "Try again, or turn PostGuard off in the taskpane to send this message unencrypted."
+            )
           );
-          log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
+          const stampedRecipients = hdrRes.value[HEADER_ENCRYPTED_RECIPIENTS] ?? "";
 
-          const [to, cc] = await Promise.all([
-            getRecipientsAsync(item.to),
-            getRecipientsAsync(item.cc),
-          ]);
-
-          if (!alreadyEncrypted) {
-            if (to.length + cc.length === 0) {
-              cancelTimeout();
-              block(event, "Add at least one recipient before sending.");
-              return;
-            }
-
-            // Outlook for Mac (native WKWebView) rejects displayDialogAsync
-            // from the launchevent runtime with E_FAIL regardless of options
-            // or sizing. Tracked upstream at office-js#6677; related stale
-            // reports are #3138, #3085, and #5681. Until Microsoft restores
-            // working dialog support, deflect Mac users to the manual
-            // taskpane "Encrypt & Send" button (which uses the dialog API
-            // from the taskpane runtime, where it works). Note: this only
-            // fires when the message is *not* already encrypted — once the
-            // user has clicked Encrypt & Send in the taskpane and we see
-            // the postguard.encrypted attachment, we fall through to the
-            // standard allow-send path. Remove this branch when 6677 ships.
-            if (Office.context.platform === Office.PlatformType.Mac) {
-              log("Outlook for Mac detected; deferring to taskpane flow");
-              cancelTimeout();
-              block(event, MAC_NOT_SUPPORTED_MESSAGE);
-              return;
-            }
-
+          item.getAttachmentsAsync(async (attRes) => {
+            // Inner guard: anything that throws (or any async rejection
+            // we forgot to handle) inside this async callback must
+            // route to blockSend, not bubble up as an unhandled rejection
+            // that lets the Smart Alert timer eventually release the
+            // send. We're past the committedToEncrypt point.
             try {
-              await encryptAndApply(event, item, to, cc, attachments);
+              log(`getAttachmentsAsync status=${attRes.status}`);
+              const attachments =
+                attRes.status === Office.AsyncResultStatus.Succeeded ? attRes.value : [];
+              const alreadyEncrypted = attachments.some(
+                (a) => a.name?.toLowerCase() === POSTGUARD_ENCRYPTED_FILENAME
+              );
+              log(`alreadyEncrypted=${alreadyEncrypted} (${attachments.length} attachments)`);
+
+              const [to, cc] = await Promise.all([
+                getRecipientsAsync(item.to),
+                getRecipientsAsync(item.cc),
+              ]);
+
+              if (!alreadyEncrypted) {
+                if (to.length + cc.length === 0) {
+                  cancelTimeout();
+                  blockSend("Add at least one recipient before sending.");
+                  return;
+                }
+
+                // Outlook for Mac (native WKWebView) rejects displayDialogAsync
+                // from the launchevent runtime with E_FAIL regardless of options
+                // or sizing. Tracked upstream at office-js#6677; related stale
+                // reports are #3138, #3085, and #5681. Until Microsoft restores
+                // working dialog support, deflect Mac users to the manual
+                // taskpane "Encrypt & Send" button (which uses the dialog API
+                // from the taskpane runtime, where it works). Note: this only
+                // fires when the message is *not* already encrypted — once the
+                // user has clicked Encrypt & Send in the taskpane and we see
+                // the postguard.encrypted attachment, we fall through to the
+                // standard allow-send path. Remove this branch when 6677 ships.
+                if (Office.context.platform === Office.PlatformType.Mac) {
+                  log("Outlook for Mac detected; deferring to taskpane flow");
+                  cancelTimeout();
+                  blockSend(MAC_NOT_SUPPORTED_MESSAGE);
+                  return;
+                }
+
+                try {
+                  await encryptAndApply(event, item, to, cc, attachments);
+                  cancelTimeout();
+                  if (!settled) {
+                    settled = true;
+                    event.completed({ allowEvent: true });
+                  }
+                } catch (e) {
+                  cancelTimeout();
+                  blockSend(`PostGuard encryption failed: ${stringifyError(e)}`);
+                }
+                return;
+              }
+
+              // Verify the encryption matches the message's current To+Cc list.
+              const currentKey = recipientsKey([...to, ...cc]);
+              const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
+              log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
+
               cancelTimeout();
-              event.completed({ allowEvent: true });
+              if (stale) {
+                blockSend(STALE_ENCRYPTION_MESSAGE);
+                return;
+              }
+              if (!settled) {
+                settled = true;
+                event.completed({ allowEvent: true });
+              }
             } catch (e) {
               cancelTimeout();
-              block(event, `Encryption failed: ${stringifyError(e)}`);
+              blockSend(`PostGuard encryption failed: ${stringifyError(e)}`);
             }
-            return;
-          }
-
-          // Verify the encryption matches the message's current To+Cc list.
-          const currentKey = recipientsKey([...to, ...cc]);
-          const stale = stampedRecipients === "" || currentKey !== stampedRecipients;
-          log(`stamped=${stampedRecipients || "<empty>"} current=${currentKey} stale=${stale}`);
-
-          cancelTimeout();
-          if (stale) {
-            block(event, STALE_ENCRYPTION_MESSAGE);
-            return;
-          }
-          event.completed({ allowEvent: true });
-        });
+          });
+        } catch (e) {
+          onFailure(`unexpected error after header read: ${stringifyError(e)}`);
+        }
       }
     );
   } catch (e) {
-    releaseSend(`unexpected error in handler: ${stringifyError(e)}`);
+    onFailure(`unexpected error before main flow: ${stringifyError(e)}`);
   }
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -14,6 +14,8 @@ const en: Bundle = {
 
   composeSwitchBarEnabled: "PostGuard encryption is on",
   composeSwitchBarDisabled: "PostGuard encryption is off. Sensitive content? Turn it on.",
+  composeEncryptionOnBanner: "PostGuard is on — this message will be encrypted on send.",
+  composeEncryptionOffBanner: "PostGuard is off — this message will be sent unencrypted.",
   manageAccess: "Manage Access",
   sign: "Sign",
   encryptAndSend: "Encrypt & Send",
@@ -70,6 +72,10 @@ const en: Bundle = {
   recipientUnknown: "This message was not encrypted for the mail account it was received on.",
 
   settingsTitle: "PostGuard Settings",
+  settingsEncryptionTitle: "Encryption",
+  settingsEncryptionDefaultLabel: "Encrypt new messages by default",
+  settingsEncryptionDefaultHelp:
+    "Off by default. When on, every new message starts with PostGuard encryption enabled and shows a banner in the message until you turn it off in the compose taskpane.",
   settingsPrefillTitle: "Sender attributes",
   settingsPrefillHelp:
     "These attributes are always offered when you sign a message. Fill in a value to make the disclosure mandatory (the Yivi app must match it). Leave blank to keep the attribute optional — you decide in the Yivi app at signing time.",
@@ -100,6 +106,8 @@ const nl: Bundle = {
 
   composeSwitchBarEnabled: "PostGuard-versleuteling staat aan",
   composeSwitchBarDisabled: "PostGuard-versleuteling staat uit. Gevoelige inhoud? Schakel het in.",
+  composeEncryptionOnBanner: "PostGuard staat aan — dit bericht wordt bij verzenden versleuteld.",
+  composeEncryptionOffBanner: "PostGuard staat uit — dit bericht wordt onversleuteld verzonden.",
   manageAccess: "Toegang beheren",
   sign: "Ondertekenen",
   encryptAndSend: "Versleutelen en verzenden",
@@ -158,6 +166,10 @@ const nl: Bundle = {
     "Dit bericht is niet versleuteld voor het e-mailaccount waarop het is ontvangen.",
 
   settingsTitle: "PostGuard-instellingen",
+  settingsEncryptionTitle: "Versleuteling",
+  settingsEncryptionDefaultLabel: "Nieuwe berichten standaard versleutelen",
+  settingsEncryptionDefaultHelp:
+    "Standaard uit. Wanneer aan, start elk nieuw bericht met PostGuard-versleuteling ingeschakeld en wordt een banner in het bericht getoond totdat je het uitschakelt in het opstel-taakvenster.",
   settingsPrefillTitle: "Afzenderattributen",
   settingsPrefillHelp:
     "Deze attributen worden altijd aangeboden wanneer je een bericht ondertekent. Vul een waarde in om de onthulling verplicht te maken (de Yivi-app moet exact deze waarde tonen). Laat leeg om het attribuut optioneel te houden — dan beslis je in de Yivi-app of je het onthult.",

--- a/src/lib/office-helpers.ts
+++ b/src/lib/office-helpers.ts
@@ -244,3 +244,11 @@ export function showNotification(
   };
   return p<void>((cb) => item.notificationMessages.replaceAsync(key, details, cb));
 }
+
+export function removeNotification(key: string): Promise<void> {
+  const item = Office.context.mailbox.item;
+  if (!item || !item.notificationMessages) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    item.notificationMessages.removeAsync(key, () => resolve());
+  });
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -22,6 +22,22 @@ export function setAllowOptimisticDialog(value: boolean): Promise<void> {
   return setSetting<boolean>(ALLOW_OPTIMISTIC_DIALOG_KEY, value);
 }
 
+// Mailbox-wide "encrypt on send" default. Off by default — the user must
+// explicitly opt in either from the compose toggle or the Settings view.
+// Both the compose taskpane and the OnMessageSend launchevent runtime read
+// this; the launchevent only falls back to it when the per-draft
+// x-pg-encrypt-on-send header is absent, so a draft the user explicitly
+// toggled keeps its choice even if the global default changes later.
+export const ENCRYPTION_ENABLED_KEY = "pg.encryptionEnabled";
+
+export function getEncryptionEnabled(): boolean {
+  return getSetting<boolean>(ENCRYPTION_ENABLED_KEY, false);
+}
+
+export function setEncryptionEnabled(value: boolean): Promise<void> {
+  return setSetting<boolean>(ENCRYPTION_ENABLED_KEY, value);
+}
+
 // Sign-attribute prefills. The three Yivi attribute types listed below are
 // always offered for disclosure when the user signs a message. If the user
 // has filled in a value in Settings, it is sent as a mandatory disclosure

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -18,6 +18,7 @@ import {
   getItemHeaders,
   getSenderEmail,
   showNotification,
+  removeNotification,
 } from "../lib/office-helpers";
 import { toBase64 } from "../lib/encoding";
 import { EMAIL_ATTRIBUTE_TYPE } from "../lib/attributes";
@@ -128,20 +129,25 @@ const state: ComposeState = {
   encryptedRecipientsHeader: null,
 };
 
-// Single notification key for the encryption-status banner. Reusing the
-// same key means replaceAsync swaps the message in place instead of
-// stacking two banners.
+// Single notification key for the encryption-status banner.
 const ENCRYPTION_STATUS_NOTIFICATION_KEY = "postguard-encryption-status";
 
 // Show the persistent in-message banner that mirrors the toggle. The
 // taskpane is not always open while the user composes, so this banner is
 // the user-visible "PostGuard is on/off" indicator on the message itself.
-// Best-effort — a notificationMessages failure shouldn't break compose.
+//
+// Implementation note: new Outlook's notificationMessages.replaceAsync
+// silently no-ops in compose mode when called with the same key — the
+// callback reports success but the visible banner text doesn't change.
+// Remove the existing entry first and then add the new one so the
+// renderer actually re-paints. Best-effort throughout; a
+// notificationMessages failure shouldn't break compose.
 async function syncEncryptionBanner(): Promise<void> {
   try {
     const message = state.encrypt
       ? t("composeEncryptionOnBanner")
       : t("composeEncryptionOffBanner");
+    await removeNotification(ENCRYPTION_STATUS_NOTIFICATION_KEY);
     await showNotification(ENCRYPTION_STATUS_NOTIFICATION_KEY, message, { persistent: true });
   } catch (_e) {
     // ignore

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -25,11 +25,7 @@ import { EMAIL_ATTRIBUTE_TYPE } from "../lib/attributes";
 import { Policy, MimeAttachment } from "../lib/types";
 import { PKG_URL, CRYPTIFY_URL, POSTGUARD_WEBSITE_URL, clientHeaders } from "../lib/pkg-client";
 import { POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
-import {
-  buildSignAttributes,
-  getEncryptionEnabled,
-  setEncryptionEnabled,
-} from "../lib/settings";
+import { buildSignAttributes, getEncryptionEnabled } from "../lib/settings";
 import { t } from "../lib/i18n";
 import { mountPolicyPanel } from "./policy-editor";
 import { showView, setStatus, showError } from "./taskpane";
@@ -38,6 +34,12 @@ const ADDIN_VERSION = "0.1.0";
 
 // Internet-header keys shared with the OnMessageSend handler. Custom header
 // names must be x-prefixed.
+//
+// Per-draft "encrypt this message on send" flag. This header is the
+// single source of truth at send time — the OnMessageSend handler only
+// runs the encryption flow when it reads "true" here, so the user's
+// global Encryption setting only acts as the default that
+// OnNewMessageCompose seeds onto each new draft.
 const HEADER_ENCRYPT_ON_SEND = "x-pg-encrypt-on-send";
 // Comma-joined sorted list of lowercase To+Cc emails captured at encrypt
 // time. The handler compares this against the message's current recipients
@@ -54,17 +56,14 @@ const POSTGUARD_VERSION = "0.1.0";
 
 async function persistEncryptOnSend(value: boolean): Promise<void> {
   try {
-    // saveItem() before and after the header write: the first ensures the
-    // draft has an itemId, the second flushes the header change to the
-    // server so the OnMessageSend handler sees it.
-    //
-    // Always write an explicit "true" or "false" — if we removed the
-    // header for the off state, a draft the user explicitly toggled off
-    // would reopen as default-on (since "absent" means "no choice yet").
+    // saveItem() before and after the header write: the first ensures
+    // the draft has an itemId, the second flushes the header change to
+    // the server so the OnMessageSend handler sees it. The header is
+    // always set to an explicit "true" or "false" so the send-side
+    // handler never has to fall back to anything else.
     await saveItem();
     await setItemHeaders({ [HEADER_ENCRYPT_ON_SEND]: value ? "true" : "false" });
     await saveItem();
-
     console.log(`[pg] persisted encryptOnSend=${value}`);
   } catch (e) {
     console.error(`[pg] failed to persist encryptOnSend:`, e);
@@ -187,13 +186,12 @@ export async function mountComposeView(): Promise<void> {
 
   toggle.addEventListener("change", () => {
     state.encrypt = toggle.checked;
-    // The toggle is the global control: write the per-draft header so the
-    // OnMessageSend handler agrees with what the user sees, AND write the
-    // mailbox-wide default so future new drafts open in the same state.
+    // Write the per-draft header. The OnMessageSend handler reads only
+    // this header — never the global setting — so a PostGuard outage
+    // can never block an unencrypted send. The global Encryption
+    // setting in the Settings view changes only the default for new
+    // drafts (seeded by OnNewMessageCompose).
     void persistEncryptOnSend(state.encrypt);
-    void setEncryptionEnabled(state.encrypt).catch((err) => {
-      console.error("[pg-compose] failed to persist global encryption setting:", err);
-    });
     void syncEncryptionBanner();
     renderToggleUI();
     renderPolicyPanels();
@@ -217,15 +215,10 @@ export async function mountComposeView(): Promise<void> {
     showView("compose");
   });
 
-  // Restore the toggle state from the per-draft header so a soft-block
-  // round trip or a taskpane reopen doesn't lose the user's choice.
-  // The header has three states:
-  //   "true"  → user explicitly enabled on this draft
-  //   "false" → user explicitly disabled on this draft
-  //   absent  → never interacted; fall back to the mailbox-wide default
-  //             (off unless the user enabled it globally). Persist the
-  //             current intent so the OnMessageSend handler sees the
-  //             same state the toggle visually shows.
+  // The per-draft header is authoritative. OnNewMessageCompose seeds
+  // it from the mailbox-wide default on compose open, but the user may
+  // have opened the taskpane before OnNewMessageCompose ran (or on a
+  // draft that predates it), so seed here too if missing.
   try {
     const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND]);
     const v = headers[HEADER_ENCRYPT_ON_SEND];
@@ -238,7 +231,8 @@ export async function mountComposeView(): Promise<void> {
       void persistEncryptOnSend(state.encrypt);
     }
   } catch (_e) {
-    // Header read failed — fall back to the mailbox-wide default.
+    // Header read failed — fall back to the mailbox-wide default; the
+    // user can still flip the toggle which will write the header.
     state.encrypt = getEncryptionEnabled();
   }
 

--- a/src/taskpane/compose-view.ts
+++ b/src/taskpane/compose-view.ts
@@ -24,7 +24,11 @@ import { EMAIL_ATTRIBUTE_TYPE } from "../lib/attributes";
 import { Policy, MimeAttachment } from "../lib/types";
 import { PKG_URL, CRYPTIFY_URL, POSTGUARD_WEBSITE_URL, clientHeaders } from "../lib/pkg-client";
 import { POSTGUARD_ENCRYPTED_FILENAME } from "../lib/mime";
-import { buildSignAttributes } from "../lib/settings";
+import {
+  buildSignAttributes,
+  getEncryptionEnabled,
+  setEncryptionEnabled,
+} from "../lib/settings";
 import { t } from "../lib/i18n";
 import { mountPolicyPanel } from "./policy-editor";
 import { showView, setStatus, showError } from "./taskpane";
@@ -113,7 +117,7 @@ interface ComposeState {
 }
 
 const state: ComposeState = {
-  encrypt: true,
+  encrypt: false,
   policy: {},
   recipients: { to: [], cc: [], bcc: [] },
   busy: false,
@@ -123,6 +127,26 @@ const state: ComposeState = {
   encryptedSnapshot: null,
   encryptedRecipientsHeader: null,
 };
+
+// Single notification key for the encryption-status banner. Reusing the
+// same key means replaceAsync swaps the message in place instead of
+// stacking two banners.
+const ENCRYPTION_STATUS_NOTIFICATION_KEY = "postguard-encryption-status";
+
+// Show the persistent in-message banner that mirrors the toggle. The
+// taskpane is not always open while the user composes, so this banner is
+// the user-visible "PostGuard is on/off" indicator on the message itself.
+// Best-effort — a notificationMessages failure shouldn't break compose.
+async function syncEncryptionBanner(): Promise<void> {
+  try {
+    const message = state.encrypt
+      ? t("composeEncryptionOnBanner")
+      : t("composeEncryptionOffBanner");
+    await showNotification(ENCRYPTION_STATUS_NOTIFICATION_KEY, message, { persistent: true });
+  } catch (_e) {
+    // ignore
+  }
+}
 
 // Stringified form of everything that affects the encrypted output. If this
 // changes after a successful encrypt, the message no longer matches the
@@ -157,7 +181,14 @@ export async function mountComposeView(): Promise<void> {
 
   toggle.addEventListener("change", () => {
     state.encrypt = toggle.checked;
+    // The toggle is the global control: write the per-draft header so the
+    // OnMessageSend handler agrees with what the user sees, AND write the
+    // mailbox-wide default so future new drafts open in the same state.
     void persistEncryptOnSend(state.encrypt);
+    void setEncryptionEnabled(state.encrypt).catch((err) => {
+      console.error("[pg-compose] failed to persist global encryption setting:", err);
+    });
+    void syncEncryptionBanner();
     renderToggleUI();
     renderPolicyPanels();
   });
@@ -183,11 +214,12 @@ export async function mountComposeView(): Promise<void> {
   // Restore the toggle state from the per-draft header so a soft-block
   // round trip or a taskpane reopen doesn't lose the user's choice.
   // The header has three states:
-  //   "true"  → user explicitly enabled
-  //   "false" → user explicitly disabled
-  //   absent  → never interacted; fall back to the default-on behaviour
-  //             and persist "true" so the OnMessageSend handler sees the
-  //             same intent the toggle visually shows.
+  //   "true"  → user explicitly enabled on this draft
+  //   "false" → user explicitly disabled on this draft
+  //   absent  → never interacted; fall back to the mailbox-wide default
+  //             (off unless the user enabled it globally). Persist the
+  //             current intent so the OnMessageSend handler sees the
+  //             same state the toggle visually shows.
   try {
     const headers = await getItemHeaders([HEADER_ENCRYPT_ON_SEND]);
     const v = headers[HEADER_ENCRYPT_ON_SEND];
@@ -196,16 +228,18 @@ export async function mountComposeView(): Promise<void> {
     } else if (v === "false") {
       state.encrypt = false;
     } else {
-      state.encrypt = true;
-      void persistEncryptOnSend(true);
+      state.encrypt = getEncryptionEnabled();
+      void persistEncryptOnSend(state.encrypt);
     }
   } catch (_e) {
-    // Header read failed — leave the default-on state alone.
+    // Header read failed — fall back to the mailbox-wide default.
+    state.encrypt = getEncryptionEnabled();
   }
 
   await refreshRecipients();
   renderToggleUI();
   renderPolicyPanels();
+  void syncEncryptionBanner();
   bccWarning.hidden = state.recipients.bcc.length === 0 || !state.encrypt;
 
   // Live recipient updates (Mailbox 1.7+). Without this the toggle UI is

--- a/src/taskpane/settings-view.ts
+++ b/src/taskpane/settings-view.ts
@@ -14,8 +14,10 @@ import {
   SIGN_PREFILL_MOBILE,
   SignPrefillType,
   getAllowOptimisticDialog,
+  getEncryptionEnabled,
   getSignPrefills,
   setAllowOptimisticDialog,
+  setEncryptionEnabled,
   setSignPrefills,
 } from "../lib/settings";
 import { t } from "../lib/i18n";
@@ -37,6 +39,13 @@ export function mountSettingsView(returnTo: ViewName): void {
 
 function refreshLabels(): void {
   byId<HTMLElement>("pg-settings-title").textContent = t("settingsTitle");
+  byId<HTMLElement>("pg-settings-encryption-title").textContent = t("settingsEncryptionTitle");
+  byId<HTMLElement>("pg-settings-encryption-default-label").textContent = t(
+    "settingsEncryptionDefaultLabel"
+  );
+  byId<HTMLElement>("pg-settings-encryption-default-help").textContent = t(
+    "settingsEncryptionDefaultHelp"
+  );
   byId<HTMLElement>("pg-settings-prefill-title").textContent = t("settingsPrefillTitle");
   byId<HTMLElement>("pg-settings-prefill-help").textContent = t("settingsPrefillHelp");
   byId<HTMLElement>("pg-settings-advanced-title").textContent = t("settingsAdvancedTitle");
@@ -55,6 +64,7 @@ function refreshLabels(): void {
 
 function refreshValues(): void {
   const prefills = getSignPrefills();
+  byId<HTMLInputElement>("pg-toggle-encryption-default").checked = getEncryptionEnabled();
   byId<HTMLInputElement>("pg-prefill-fullname").value = prefills[SIGN_PREFILL_FULLNAME] ?? "";
   byId<HTMLInputElement>("pg-prefill-dateofbirth").value = ddmmyyyyToHtml(
     prefills[SIGN_PREFILL_DATEOFBIRTH] ?? ""
@@ -65,6 +75,14 @@ function refreshValues(): void {
 }
 
 function wireListeners(): void {
+  byId<HTMLInputElement>("pg-toggle-encryption-default").addEventListener("change", () => {
+    const checked = byId<HTMLInputElement>("pg-toggle-encryption-default").checked;
+    void setEncryptionEnabled(checked).catch((err) => {
+      console.error("[pg-settings] failed to persist encryption default", err);
+      setStatus(t("settingsSaveError"), "error");
+    });
+  });
+
   byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog").addEventListener("change", () => {
     const checked = byId<HTMLInputElement>("pg-toggle-allow-optimistic-dialog").checked;
     void setAllowOptimisticDialog(checked).catch((err) => {

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -96,6 +96,20 @@
       <section id="view-settings" class="pg-view" hidden>
         <h2 id="pg-settings-title" class="pg-section-title"></h2>
 
+        <h3 id="pg-settings-encryption-title" class="pg-section-title pg-section-subtitle"></h3>
+        <div class="pg-toggle-row">
+          <label class="pg-switch">
+            <input
+              type="checkbox"
+              id="pg-toggle-encryption-default"
+              aria-labelledby="pg-settings-encryption-default-label"
+            />
+            <span class="pg-switch-track" aria-hidden="true"></span>
+          </label>
+          <span id="pg-settings-encryption-default-label" class="pg-toggle-label"></span>
+        </div>
+        <p id="pg-settings-encryption-default-help" class="pg-subtitle"></p>
+
         <h3 id="pg-settings-prefill-title" class="pg-section-title pg-section-subtitle"></h3>
         <p id="pg-settings-prefill-help" class="pg-subtitle"></p>
         <div class="pg-policy-attr">


### PR DESCRIPTION
## Summary

- **Default PostGuard off, with a mailbox-wide toggle.** New roaming setting `pg.encryptionEnabled` (default `false`) seeds every new draft. Exposed from the Settings view and via the existing compose toggle. Old behavior was opt-out (default on).
- **Per-draft control via an internet header.** `x-pg-encrypt-on-send` (`"true"` / `"false"`) is the only thing `OnMessageSend` consults. Compose toggle writes only this header; the global setting just provides the seed value.
- **`OnNewMessageCompose` launch event.** Fires when a new compose / reply / forward opens. Seeds the per-draft header from the global default and paints the persistent in-message banner — so the user sees "PostGuard is on/off" immediately, without having to click the ribbon.
- **Notification banner on the compose item.** Persistent, always reflects the per-draft state. Uses remove-then-replace to dodge an Outlook quirk where `replaceAsync` silently no-ops on the same key (logged in `docs/outlook-quirks.md`).
- **Fail-closed when encryption was requested, fail-open otherwise.** Once the header is read as `"true"` a `committedToEncrypt` latch flips, and every failure path (encrypt error, timeout, unhandled exception in the async callback) now blocks the send via a Smart Alert. If the header is `"false"`, absent, or unreadable, the handler releases the send in cleartext immediately — a PostGuard outage can no longer block an unencrypted send.

## Test plan

- [x] In Settings, with **Encrypt new messages by default = off**: open a new message → banner reads "PostGuard is off — this message will be sent unencrypted." Send goes through with no PostGuard involvement.
- [x] Flip to **on** in Settings → open a new message → banner reads "PostGuard is on …" and Send triggers the Yivi dialog.
- [x] Toggle the compose-view switch on an open draft → banner text swaps in place (not stacked).
- [x] Send a draft with header `"true"` and PKG_URL pointed somewhere unreachable → expect a Smart Alert "PostGuard encryption failed: …", message **not** sent.
- [x] Send a draft with header `"true"` and never scan the QR → after ~4½ min expect a Smart Alert "PostGuard encryption did not finish in time. The message was NOT sent."
- [x] Send a draft with header `"false"` (or no PostGuard interaction) → goes out unencrypted, no banner alarm even if PKG is down.
- [x] Reply / forward an existing email → `OnNewMessageCompose` fires and the banner appears before the taskpane is opened.