### PR TITLE
ci: add prettier format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Lint (no errors, no warnings)
         run: npx eslint -c eslint.config.mjs --max-warnings=0 "src/**/*.{ts,js}"
 
+      - name: Prettier (format check)
+        run: npx prettier --check "src/**/*.{ts,js}"
+
       - name: Typecheck
         run: npx tsc --noEmit
 


### PR DESCRIPTION
## Summary
- Adds a `Prettier (format check)` step to `.github/workflows/ci.yml` after the Lint step, so formatting drift fails CI instead of landing silently on master.
- Uses `npx prettier --check "src/**/*.{ts,js}"` directly rather than `npm run prettier`. The npm script wraps `office-addin-lint prettier`, which runs prettier with `--write` (so it would silently reformat in CI instead of failing on drift) and additionally exits 2 on this repo because it hardcodes `src/**/*.{ts,tsx,js,jsx}` and there are no `.tsx/.js/.jsx` files. The pattern mirrors the existing Lint step's glob for consistency.
- No source files needed reformatting — `npx prettier --check "src/**/*.{ts,js}"` is clean against current `master`.

Closes #77

## Test plan
- [ ] CI on this PR runs the new "Prettier (format check)" step and passes.
- [ ] Confirm a deliberately misformatted file in a follow-up branch fails the new step (smoke check for drift detection).