### PR TITLE
feat(metrics): tag cryptify uploads with X-Cryptify-Source: outlook

### DIFF
--- a/src/lib/pkg-client.ts
+++ b/src/lib/pkg-client.ts
@@ -15,5 +15,11 @@ export const CLIENT_ID = "pg4ol";
 export function clientHeaders(addinVersion: string): Record<string, string> {
   return {
     "X-PostGuard-Client-Version": `${CLIENT_NAME},1.0,${CLIENT_ID},${addinVersion}`,
+    // Identifies this add-in in cryptify's per-channel upload metrics.
+    // Required because cryptify's detect_channel checks the Origin
+    // header before User-Agent, and the add-in is served from
+    // addin.*.postguard.eu — without this header it would be
+    // misclassified as `website` / `staging-website`.
+    "X-Cryptify-Source": "outlook",
   };
 }


### PR DESCRIPTION
## Summary
Adds `X-Cryptify-Source: outlook` to `clientHeaders()` so cryptify's per-channel upload metrics ([encryption4all/cryptify#102](https://github.com/encryption4all/cryptify/pull/102)) classify this add-in deterministically.

## Why
Cryptify's `detect_channel` falls back through three layers: explicit `X-Cryptify-Source` header → API auth → `Origin` substring → `User-Agent` substring. The add-in is served from `addin.*.postguard.eu`, which matches the `Origin` rule (`contains("postguard.")`) *before* the User-Agent rule (`contains("outlook")`) ever gets to run — so without an explicit header, Outlook uploads would be misclassified as `website` (or `staging-website` in dev). Setting the header here removes the ambiguity at the source, and is symmetric with parallel PRs in postguard-website and postguard-tb-addon.

## Test plan
- [ ] In a dev build, compose + send an encrypted attachment via the add-in.
- [ ] In Cockpit Grafana Explore on the custom metrics DS: `cryptify_uploads_total{channel="outlook"}` should increment by 1.

## Note
There is a preexisting `tsc --noEmit` error in `src/lib/pending-upload.ts` (missing `resumeUpload` export from `@e4a/pg-js`) — unrelated to this change.